### PR TITLE
fix: add explicit clawhub login step in CI

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -20,9 +20,10 @@ jobs:
       - name: Install ClawHub CLI
         run: npm install -g clawhub
 
+      - name: Login to ClawHub
+        run: clawhub login --token "${{ secrets.CLAWHUB_TOKEN }}" --no-browser
+
       - name: Publish to ClawHub
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           clawhub publish ./skills/heygen \
             --slug video-agent \


### PR DESCRIPTION
Fixes the GitHub Action failing with 'Error: Not logged in'.

Added explicit login step before publishing using the CLAWHUB_TOKEN secret.

The ClawHub CLI doesn't automatically pick up the token from environment variables - it needs an explicit login command.