### PR TITLE
refactor(prompt-optimizer): split into 3 files, add beacon-signal insights

### DIFF
--- a/skills/heygen/SKILL.md
+++ b/skills/heygen/SKILL.md
@@ -31,7 +31,7 @@ Only use v2/video/generate when user explicitly needs:
 
 | Task | Read |
 |------|------|
-| Generate video from prompt (easy) | [prompt-optimizer.md](references/prompt-optimizer.md) → [video-agent.md](references/video-agent.md) |
+| Generate video from prompt (easy) | [prompt-optimizer.md](references/prompt-optimizer.md) → [visual-styles.md](references/visual-styles.md) → [video-agent.md](references/video-agent.md) |
 | Generate video with precise control | [video-generation.md](references/video-generation.md), [avatars.md](references/avatars.md), [voices.md](references/voices.md) |
 | Check video status / get download URL | [video-status.md](references/video-status.md) |
 | Add captions or text overlays | [captions.md](references/captions.md), [text-overlays.md](references/text-overlays.md) |
@@ -54,7 +54,9 @@ Only use v2/video/generate when user explicitly needs:
 - [references/scripts.md](references/scripts.md) - Writing scripts, pauses, pacing
 - [references/video-generation.md](references/video-generation.md) - POST /v2/video/generate and multi-scene videos
 - [references/video-agent.md](references/video-agent.md) - One-shot prompt video generation
-- [references/prompt-optimizer.md](references/prompt-optimizer.md) - Writing effective Video Agent prompts
+- [references/prompt-optimizer.md](references/prompt-optimizer.md) - Writing effective Video Agent prompts (core workflow + rules)
+- [references/visual-styles.md](references/visual-styles.md) - 20 named visual styles with full specs
+- [references/prompt-examples.md](references/prompt-examples.md) - Full production prompt example + ready-to-use templates
 - [references/dimensions.md](references/dimensions.md) - Resolution and aspect ratios
 
 ### Video Customization

--- a/skills/heygen/references/prompt-examples.md
+++ b/skills/heygen/references/prompt-examples.md
@@ -1,0 +1,206 @@
+---
+name: prompt-examples
+description: Full production prompt examples and ready-to-use templates for Video Agent
+---
+
+# Video Agent Prompt Examples
+
+## Full Example: Brief to Production Prompt
+
+### Input Brief
+
+```
+Topic: Monthly company report for a SaaS startup
+Key data: $141M ARR (up from $54M), 1.85M signups (+28%), 3M paid videos/month
+Customer story: Creator built AI character, 2.5M followers, 20 min/video
+Challenge: Organic traffic volatile, -16% last week
+Duration: ~90 seconds
+Tone: Confident CEO, data-backed
+```
+
+### Output Prompt
+
+```
+FORMAT: Bloomberg-style company report. 90 seconds. Fast-paced, data-dense.
+Record-breaking month. Proud but analytical.
+
+TONE: Confident, direct, data-backed. Highlights hit hard with numbers.
+Customer stories are the emotional core. Challenges are honest — no spin.
+
+AVATAR: Man in simple black crew-neck tee, standing in a modern glass-walled
+office at golden hour. Behind him, a wall-mounted display shows the company logo
+in soft blue glow. Monitor to his right shows a dashboard with upward-trending
+charts. Desk beside him: laptop, half-empty flat white, scattered sticky notes.
+Warm afternoon light through floor-to-ceiling windows, long shadows on polished
+concrete. Minimal, focused startup HQ.
+
+STYLE — SWISS PULSE (Müller-Brockmann): Grid-locked compositions. Black (#1a1a1a),
+white, electric blue (#0066FF), warm amber (#FF9500) for records. Helvetica Bold
+headlines, Regular labels. Numbers LARGE. Animated counters count up from 0.
+Diagonal compositions on accent moments. Grid wipe transitions. No dissolves.
+
+CRITICAL ON-SCREEN TEXT (display literally):
+- "1.85M SIGNUPS — +28% MoM"
+- "$2.12M NEW SUBSCRIPTION REVENUE"
+- "$54M → $141M ARR"
+- "2.5M FOLLOWERS" and "20 MIN / VIDEO"
+- Quote: "Use technology to serve the message, not distract from it."
+- "ORGANIC: 65% OF SUBS — VOLATILE"
+
+MUSIC: Upbeat electronic with a driving beat. Tycho meets Bloomberg opening theme.
+Builds through highlights, warms for customer story, softens for challenges, peaks
+on close.
+
+---
+
+SCENE 1 — A-ROLL (8s)
+[Avatar center-frame, energetic, leaning slightly forward]
+VOICEOVER: "January was a record month. New highs across acquisition, revenue,
+and product velocity. Here's the full picture."
+Lower-third SLIDES in: "COMPANY NAME | JANUARY 2026" white on blue bar.
+Grid wipe.
+
+SCENE 2 — FULL SCREEN B-ROLL (12s)
+[NO AVATAR — motion graphic only]
+VOICEOVER: "One-point-eight-five million signups — twenty-eight percent month
+over month. Two-point-one-two million in new subscription revenue. Both all-time
+highs."
+LAYER 1: Dark #1a1a1a background with thin grid lines pulsing at 8% opacity.
+LAYER 2: "1.85M" SLAMS in from left, white Bold 140pt. "SIGNUPS" types on
+         in electric blue 32pt uppercase. "+28% MoM" appears in amber.
+LAYER 3: Three stat cards CASCADE from top-right, staggered 0.3s:
+         "$2.12M New Revenue" — "$3.4M Business ARR" — "$3M Pro ARR."
+         Each number COUNTS UP from 0.
+LAYER 4: Bottom ticker scrolls: "Non-brand search +36% • Brand impressions 9.2M
+         • Weekly subs +20.5%"
+LAYER 5: Grid lines RIPPLE outward on "1.85M" slam. Diagonal amber bar behind
+         stat cards.
+Hard cut.
+
+SCENE 3 — FULL SCREEN B-ROLL (12s)
+[NO AVATAR — motion graphic only]
+VOICEOVER: "Zoom out. Twelve months ago — fifty-four million ARR. Today —
+one hundred forty-one million. Nearly three X in a single year."
+LAYER 1: Dark background, subtle grid scrolling upward.
+LAYER 2: Animated line chart DRAWS ITSELF left to right. Y-axis: $50M to $150M.
+         Final point "$140.84M" glows amber and pulses.
+LAYER 3: Milestone annotations float in at key data points.
+LAYER 4: Second smaller chart below — "Paid Videos" 0.91M to 2.97M, same style.
+LAYER 5: Thin grid lines converge toward final data point. Scan line sweeps.
+Grid wipe.
+
+SCENE 4 — A-ROLL (8s)
+[Avatar center-frame, warm tone, genuine smile]
+VOICEOVER: "But the numbers only tell half the story. The other half is the
+people building on the platform."
+Lower-third: "Customer Spotlight"
+
+SCENE 5 — FULL SCREEN B-ROLL (12s)
+[NO AVATAR — warm palette]
+VOICEOVER: "An AI character built entirely on the platform. Twenty minutes
+per video. Two-point-five million Instagram followers. The creator's principle:
+use technology to serve the message, not distract from it."
+LAYER 1: Dark background with warm amber grid lines at low opacity.
+LAYER 2: "CHARACTER NAME" in large white, center-top, 80pt.
+LAYER 3: Stats cascade from right: "2.5M Followers" COUNTS UP in amber —
+         "20 min/video" — "7x Faster." Each a glowing node.
+LAYER 4: Quote card SLIDES UP: "Use technology to serve the message, not
+         distract from it." Types on word by word.
+LAYER 5: Warm light bloom. Grid lines soften into curved arcs.
+Grid wipe.
+
+SCENE 6 — A-ROLL (10s)
+[Avatar center-frame, serious/candid]
+VOICEOVER: "Now the honest part. Organic drives sixty-five percent of
+subscriptions and it's volatile. Non-brand traffic dropped sixteen percent
+last week. We've rebuilt attribution and we're investing in SEO."
+Lower-third: "Challenges"
+
+SCENE 7 — A-ROLL (7s)
+[Avatar center-frame, energy lifts, direct eye contact]
+VOICEOVER: "Fifty-four million to one-forty-one in twelve months. Three million
+paid videos a month. January set the bar — now we raise it."
+End card: Logo centered, blue glow fade-in. Grid lines converge. Music peaks.
+
+---
+
+NARRATION STYLE: CEO energy — conviction backed by data. Fast on highlights.
+Warm on customer stories. Candid on challenges. Close with forward momentum.
+```
+
+## Ready-to-Use Templates
+
+### Tech News Briefing
+```
+FORMAT: 75-second high-energy tech briefing. Think: Bloomberg meets Vice.
+
+AVATAR: [Presenter in tech-casual at a multi-monitor station.
+Describe clothing, monitor content, desk items, lighting.]
+
+STYLE — DECONSTRUCTED (Brody): Dark grey #1a1a1a, rust orange #D4501E.
+Type at angles, overlapping. Gritty textures. Smash cut transitions.
+
+CRITICAL ON-SCREEN TEXT:
+- [List every stat, quote, handle that must appear]
+
+SCENE 1 — A-ROLL (8s): Hook with energy. State what's happening.
+SCENE 2 — B-ROLL (12s): First story with layered visuals (L1-L5).
+SCENE 3 — A-ROLL + OVERLAY (10s): Second story, split frame.
+SCENE 4 — B-ROLL (10s): Third story or dramatic data point.
+SCENE 5 — A-ROLL (8s): Wrap-up and forward look.
+```
+
+### Product Comparison
+```
+FORMAT: 60-second comparison. [Product A] vs [Product B]. Data-driven.
+
+AVATAR: [Presenter in review studio. Desk with both products visible.]
+
+STYLE — DIGITAL GRID (Crouwel): Dark #0a0a0a, cyan #00D4FF and amber #FFB800.
+Two-color coding: cyan = Product A, amber = Product B. Monospaced type.
+
+CRITICAL ON-SCREEN TEXT:
+- [Key stats for each product]
+- [Pricing, features, differentiators]
+
+Use SPLIT FRAME B-roll: Product A left, Product B right.
+```
+
+### Strategy Presentation
+```
+FORMAT: 90-second strategy briefing. Bloomberg meets board meeting.
+
+AVATAR: [Executive in blazer over tee. Conference room with whiteboard frameworks.]
+
+STYLE — SWISS PULSE (Müller-Brockmann): Black/white + blue #0066FF.
+Grid-locked. Helvetica. Animated counters. Grid wipe transitions.
+
+CRITICAL ON-SCREEN TEXT:
+- [Framework labels, quadrant labels, key quotes]
+
+Build frameworks visually: draw axes, plot positions, animate labels.
+```
+
+### Social Ad (30 seconds)
+```
+FORMAT: 30-second social ad. Maximum energy. Portrait 9:16.
+
+AVATAR: [Creator-style presenter. Ring light, colorful background.]
+
+STYLE — CARNIVAL SURGE (Lins): Hot pink, yellow, teal. Collage layering.
+Text MASSIVE at angles. Confetti. Smash cuts.
+
+Three scenes: Hook (8s) → Value prop (12s) → CTA (10s).
+Text fills 50-80% of every frame. Numbers SLAM.
+```
+
+### Premium Report
+```
+FORMAT: 120-second investor-grade report. Understated authority.
+
+AVATAR: [Tailored merino sweater. Architectural room, diffused natural light.]
+
+STYLE — VELVET STANDARD (Vignelli): Black, white, gold #c9a84c.
+Thin ALL CAPS, wide spacing. Generous negative space.
+Slow cross-dissolves. Numbers fade in with weight.
+```

--- a/skills/heygen/references/prompt-optimizer.md
+++ b/skills/heygen/references/prompt-optimizer.md
@@ -5,40 +5,38 @@ description: Write production-quality prompts for HeyGen Video Agent — from ba
 
 # Video Agent Prompt Optimizer
 
-## Table of Contents
-- [Prompt Anatomy](#prompt-anatomy)
-- [The Six Sections of a Great Prompt](#the-six-sections-of-a-great-prompt)
-- [Visual Style Library](#visual-style-library)
-- [Avatar Description Guide](#avatar-description-guide)
-- [Scene Types and Layout](#scene-types-and-layout)
-- [The Visual Layer System](#the-visual-layer-system)
-- [Motion Vocabulary](#motion-vocabulary)
-- [Transition Types](#transition-types)
-- [Critical On-Screen Text](#critical-on-screen-text)
-- [Music and Narration Direction](#music-and-narration-direction)
-- [Timing Guidelines](#timing-guidelines)
-- [Copy Guidelines](#copy-guidelines)
-- [Media Types: When to Use What](#media-types-when-to-use-what)
-- [Using Attachments](#using-attachments)
-- [Prompt Complexity Levels](#prompt-complexity-levels)
-- [Full Example: Brief to Production Prompt](#full-example-brief-to-production-prompt)
-- [Ready-to-Use Templates](#ready-to-use-templates)
-- [Workflow: Brief to Prompt](#workflow-brief-to-prompt)
-- [Optimization Checklist](#optimization-checklist)
-- [Common Mistakes](#common-mistakes)
+Write effective prompts for the HeyGen Video Agent API. Based on patterns from 40+ produced videos.
 
----
+**The core insight: Video Agent is an HTML interpreter.** It renders layouts, typography, and structured content natively. Describe B-roll as layered text motion graphics with action verbs ("slams in," "types on," "counts up") — not layout specs ("upper-left, 48pt").
 
-The difference between forgettable AI-generated content and professional, broadcast-quality video is how precisely you direct the Video Agent. This guide teaches a layered prompting system — from quick one-liners to fully art-directed productions — based on patterns from the highest-quality videos produced on the platform.
+## Reference Files
+
+| File | Load when... |
+|------|-------------|
+| [visual-styles.md](visual-styles.md) | Choosing a visual style (20 styles with full specs) |
+| [prompt-examples.md](prompt-examples.md) | Writing a prompt from scratch (full production example + templates) |
+
+## Workflow: Brief to Prompt
+
+1. **Pull data** — Research the topic: web search, APIs, internal docs. Gather real quotes, stats, handles
+2. **Synthesize a thesis** — Not a list. A story. *"X is happening because Y — here's the proof."* Group into 3-5 themes with a narrative arc
+3. **Choose a style** — Match mood first, content second. Ask: *"What should the viewer FEEL?"* See [visual-styles.md](visual-styles.md)
+4. **Write the avatar** — Thematic wardrobe matching content's emotional context. Brand logos and content-specific props in the set (see Avatar Guide below)
+5. **Extract critical text** — List every number, quote, handle, and label that must appear literally
+6. **Break into scenes** — One concept per scene. Rotate scene types. Never 3+ of same type in a row. At least 2 pure B-roll scenes
+7. **Write voiceover** — Spell out numbers in VO ("one-point-eight-five million"), use figures on screen ("1.85M"). Narration on EVERY scene including B-roll
+8. **Layer each B-roll scene** — L1 background, L2 hero, L3 supporting, L4 info bar, L5 effects. Every element must MOVE
+9. **Add music direction** — Reference artists, describe energy arc
+10. **Add narration style** — How to deliver: fast/slow, where to pause, emotional register per section
 
 ## Prompt Anatomy
 
-Every production-quality prompt follows this structure. Each section gives the Video Agent a different type of instruction:
+Every production-quality prompt follows this structure:
 
 ```
 FORMAT:    What kind of video, how long, what energy
 TONE:      Emotional register, references
-AVATAR:    Detailed physical + environment description
+AVATAR:    Detailed physical + environment description (60-100 words)
 STYLE:     Named aesthetic with colors, typography, motion rules, transitions
 CRITICAL ON-SCREEN TEXT:  Exact strings that must appear
 SCENE-BY-SCENE:  Individual scene breakdowns with VO and layered visuals
@@ -46,337 +44,91 @@ MUSIC:     Genre, reference artists, energy arc
 NARRATION STYLE:  How to deliver the voiceover
 ```
 
-You don't need every section for every video. But the more you include, the more control you have over the output. The sections below explain each one in detail.
-
-## The Six Sections of a Great Prompt
-
-### 1. FORMAT
-
-Sets the video type, duration, and energy level in one line.
+### FORMAT
 
 ```
 FORMAT: 75-second high-energy tech daily briefing. Think: a creator who just got amazing news.
 FORMAT: Bloomberg-style strategy briefing. 100-120 seconds. CEO-delivered.
-FORMAT: 60-second Beacon Signal — punchy tech product comparison. MKBHD meets Bloomberg.
 ```
 
-**What to include:** Duration, genre/format reference, energy level, and optionally a pop-culture comparison that sets the vibe.
-
-### 2. TONE
-
-Defines the emotional quality of the narration and visuals.
+### TONE
 
 ```
 TONE: Confident, direct, data-backed. Highlights hit hard. Lowlights are honest — no spin.
-TONE: Measured, authoritative, premium. Every word carries weight. Confidence from understatement.
 TONE: Edgy, punk tech commentary. Vice News meets The Face magazine — raw, confrontational.
 ```
 
-### 3. AVATAR
+### CRITICAL ON-SCREEN TEXT
 
-Describe your presenter in cinematic detail. The more specific, the better the result.
-
-See [Avatar Description Guide](#avatar-description-guide) below.
-
-### 4. STYLE
-
-Name a visual style, reference an artist/designer, and specify exact color codes, typography, motion rules, and transition types.
-
-See [Visual Style Library](#visual-style-library) below.
-
-### 5. CRITICAL ON-SCREEN TEXT
-
-List every exact string that must appear as readable text in the video.
-
-See [Critical On-Screen Text](#critical-on-screen-text) below.
-
-### 6. SCENE-BY-SCENE
-
-Break the video into individual scenes with scene type, visual layers, voiceover script, and duration.
-
-See [Scene Types and Layout](#scene-types-and-layout) and [The Visual Layer System](#the-visual-layer-system) below.
-
----
-
-## Visual Style Library
-
-**The single most impactful thing you can do is name a visual style.** Give it a name, reference a designer or aesthetic movement, and define its colors, typography, motion, and transitions.
-
-The styles below are **examples to use directly or as inspiration for creating your own.** You are not limited to this list — invent new styles by combining elements, referencing other designers, art movements, film genres, or cultural aesthetics. The pattern is what matters: **a named style + designer/movement reference + color palette + typography + motion rules + transition types.**
-
-For example, you could create:
-- **"Noir Signal" (Saul Bass)** — high-contrast black/white/red, dramatic shadows, bold silhouettes
-- **"Vapor Grid" (Vaporwave)** — pastel gradients, Roman busts, retro computing, VHS scan lines
-- **"Paper Cut" (Matisse)** — bold organic shapes, primary colors, hand-cut collage feel
-- **"Wire Frame" (Dieter Rams)** — ultra-minimal, thin lines, grey/white/one accent, form follows function
-
-Use the examples below as starting points or pick one that fits your content:
-
-### Swiss Pulse
-**Reference:** Josef Muller-Brockmann
-**Best for:** Data-heavy briefings, corporate reports, strategy presentations
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Black (#1a1a1a), white, ONE accent: electric blue (#0066FF) |
-| **Typography** | Helvetica Bold headlines, Regular labels. Numbers LARGE (80-120pt) |
-| **Layout** | Grid-locked compositions. Every element snaps to a 12-column grid |
-| **Motion** | Animated counters, progress bars, comparison columns. Numbers COUNT UP from 0 |
-| **Accents** | Diagonal compositions on key moments (5-15 degree tilt). Thin grid lines in backgrounds |
-| **Transitions** | Grid wipes, hard cuts. No dissolves |
+List every exact string that must appear on screen. Without this, the agent may summarize, round numbers, or rephrase quotes.
 
 ```
-STYLE — SWISS PULSE (Muller-Brockmann): Grid-locked layouts, mathematical precision.
-Black/white + electric blue #0066FF only. Helvetica Bold headlines. Data-viz hero content.
-Animated counters. Diagonal compositions on accent moments. Grid wipe transitions.
+CRITICAL ON-SCREEN TEXT (display literally):
+- "$141M ARR — All-Time High"
+- "1.85M Signups — +28% MoM"
+- Quote: "Use technology to serve the message, not distract from it." — Shalev Hani
+- "@username" — exact social handle
 ```
 
-### Deconstructed
-**Reference:** Neville Brody / The Face magazine
-**Best for:** Tech news, security alerts, punk energy, raw editorial
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Dark grey (#1a1a1a), black, rust orange (#D4501E or #FF6B35), raw white (#f0f0f0) |
-| **Typography** | Type at angles, overlapping edges, escaping frames. Bold industrial |
-| **Layout** | High contrast, gritty textures: scratched metal, peeling paint, scan-line glitch |
-| **Motion** | Text SLAMS, SHATTERS, PUNCHES. Letters scramble then snap back |
-| **Accents** | Diagonal slash marks, glitch flickers, concrete/metal textures |
-| **Transitions** | Smash cuts, glitch transitions, white flash frames |
+### MUSIC & NARRATION
 
 ```
-STYLE — DECONSTRUCTED (Neville Brody): Dark grey #1a1a1a, black, rust orange #D4501E.
-Type at angles, overlapping edges. Gritty textures: scratched metal, scan-line glitch.
-Smash cut transitions with flash frames.
+MUSIC: Driving electronic, heavy bass drops on key numbers. Run the Jewels meets
+a tech keynote. Builds relentlessly, only softens for customer stories.
+
+NARRATION STYLE: High energy throughout. Let numbers PUNCH — pause before big ones,
+then deliver hard. Customer stories get warmth. The close should feel like a mic drop.
 ```
-
-### Maximalist Type
-**Reference:** Paula Scher
-**Best for:** High-energy announcements, marketing, social content, celebrations
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Bold saturated: blue (#0066FF), amber (#FF9500), red, yellow, black, white — max contrast |
-| **Typography** | Text IS the visual. Overlapping layers at different scales and angles, filling 50-80% of frame |
-| **Layout** | Text layered OVER real footage — never on empty backgrounds |
-| **Motion** | Everything moving, slamming, sliding. Nothing stays still. 1-2 second clips in montages |
-| **Accents** | Flash frames between sections. Numbers that PUNCH on bass hits |
-| **Transitions** | Smash cuts, text slamming from edges, flash frames |
-
-```
-STYLE — MAXIMALIST TYPE (Paula Scher): Red, yellow, black, white — max contrast.
-Text IS the visual. Overlapping at different scales and angles, 50-80% of frame.
-Kinetic energy: everything moving, slamming, sliding. Smash cuts, flash frames.
-```
-
-### Data Drift
-**Reference:** Refik Anadol
-**Best for:** Premium reports, visionary content, investor-facing presentations
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Iridescent: holographic silver, electric purple (#7c3aed), cyan (#06b6d4), deep black (#0a0a0a) |
-| **Typography** | Thin futuristic sans-serif. Minimal, floating, almost weightless |
-| **Layout** | Fluid, morphing compositions. Data that flows like liquid. Extreme scale shifts |
-| **Motion** | Particles coalesce into numbers, streams of light trace data paths |
-| **Accents** | Reflective luminous surfaces, flowing light, particle clouds |
-| **Transitions** | Liquid dissolves, particles dispersing and reforming |
-
-```
-STYLE — DATA DRIFT (Refik Anadol): Iridescent palette — purple #7c3aed, cyan #06b6d4,
-deep black #0a0a0a. Fluid morphing compositions. Data flows like liquid. Thin futuristic type.
-Liquid dissolve transitions. Particles coalesce into numbers.
-```
-
-### Velvet Standard
-**Reference:** Massimo Vignelli
-**Best for:** Premium keynotes, investor updates, luxury brands, understated authority
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Black, white, ONE rich accent — deep navy (#1a237e) or gold (#c9a84c). Nothing else |
-| **Typography** | Thin sans-serif, ALL CAPS, letter-spaced wide. Refined, not loud |
-| **Layout** | Generous negative space. Symmetrical, centered, architectural precision |
-| **Motion** | Slow, deliberate. Numbers fade in with weight. Sequential reveals, not simultaneous |
-| **Accents** | Perfect lighting, no visible grain. High production quality. Restraint IS the message |
-| **Transitions** | Slow, elegant cross-dissolves. Never jarring. Deliberate pacing |
-
-```
-STYLE — VELVET STANDARD (Massimo Vignelli): Black, white, one accent: gold #c9a84c.
-Generous negative space. Symmetrical, centered. Thin sans-serif, ALL CAPS, wide letter-spacing.
-Slow elegant cross-dissolves. Restraint IS the message.
-```
-
-### Carnival Surge
-**Reference:** Rico Lins (Brazil)
-**Best for:** Social media ads, product launches, celebrations, maximum energy
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Maximum color: hot pink (#FF1493), electric yellow (#FFE000), teal (#00CED1), orange, violet |
-| **Typography** | MASSIVE, BOLD, layered at ANGLES over footage. Collage-style overlapping |
-| **Layout** | Collage layering with multiple elements overlapping. Never static |
-| **Motion** | Rapid 1-2 second clips, confetti bursts, elements bounce and overshoot |
-| **Accents** | Confetti particles, flash frames, euphoric celebratory energy |
-| **Transitions** | Smash cuts, flash frames, pop cuts |
-
-```
-STYLE — CARNIVAL SURGE (Rico Lins): Maximum color — hot pink #FF1493, electric yellow #FFE000,
-teal #00CED1, orange, violet. Collage layering. Text MASSIVE at ANGLES. Confetti bursts.
-Smash cuts and flash frames. Everything euphoric.
-```
-
-### Digital Grid
-**Reference:** Wim Crouwel
-**Best for:** Tech comparisons, platform analysis, developer content
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Dark backgrounds (#0a0a0a) with cyan (#00E5FF), amber (#FFB300), green (#00FF88) accents |
-| **Typography** | Monospaced type throughout. Code-terminal aesthetic |
-| **Layout** | Pixel grid overlays visible. Everything snaps to a system. Two-color coding for comparisons |
-| **Motion** | Grid nodes light up sequentially. Network maps activating. Data pulsing |
-| **Accents** | Scan-line effects, cursor blinks, terminal log scrolling |
-| **Transitions** | Clean wipe transitions, grid wipes |
-
-```
-STYLE — DIGITAL GRID (Wim Crouwel): Monospaced type. Dark #0a0a0a with cyan #00E5FF
-and amber #FFB800. Pixel grid overlays. Code-terminal aesthetic. Clean wipe transitions.
-```
-
-### Shadow Cut
-**Reference:** Brutalist architecture
-**Best for:** Confrontational analysis, hard comparisons, dramatic reveals
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Black (#0A0A0A), white (#F5F5F5), ONE accent: blood red (#FF0000). Nothing else |
-| **Typography** | Ultra-heavy condensed grotesque. Headlines MASSIVE, filling 70%+ of frame |
-| **Layout** | Every frame looks like a protest poster or brutalist architecture |
-| **Motion** | HARD CUTS ONLY. No easing. SLAM in, SLAM out. Frames stamped onto screen |
-| **Accents** | Concrete textures, newsprint grain. Nothing polished |
-| **Transitions** | Hard cuts. Black frame for 2 frames, then SLAM to next scene |
-
-```
-STYLE — SHADOW CUT (Brutalist): Black #0A0A0A, white, ONE accent: blood red #FF0000.
-Ultra-heavy condensed type filling 70%+ of frame. HARD CUTS ONLY. No easing.
-Concrete textures, newsprint grain. Protest poster aesthetic.
-```
-
-### Dream State
-**Reference:** Henryk Tomaszewski / Polish Poster School
-**Best for:** Brand films, artistic content, ethereal storytelling
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Soft neon gradients: lavender to coral, mint to gold. No hard edges |
-| **Typography** | Thin elegant sans-serif that FLOATS and DRIFTS. Text breathes — subtle scale oscillation |
-| **Layout** | Everything floats. Slow parallax layers at different depths. Soft focus, lens flare |
-| **Motion** | Elements morph and dissolve. Slow parallax. Bokeh orbs drift through frame |
-| **Accents** | Chromatic aberration at edges. Frosted glass look. Colors bleed like watercolors |
-| **Transitions** | NEVER hard cuts. Everything dissolves, morphs, melts into the next scene |
-
-```
-STYLE — DREAM STATE (Tomaszewski): Soft neon gradients — lavender to coral, mint to gold.
-Thin elegant floating type. Everything drifts at different parallax depths.
-Chromatic aberration. NEVER hard cuts — everything melts and morphs.
-```
-
-### Play Mode
-**Reference:** Gaming/K-pop stream aesthetic
-**Best for:** Comparisons as battles, listicles, fun educational content
-
-| Element | Specification |
-|---------|--------------|
-| **Colors** | Neon pink (#FF2D78), electric blue (#00D4FF), lime green (#7FFF00), hot purple (#BF00FF) |
-| **Typography** | Bold with scanline overlay. Glossy with sparkle particles |
-| **Layout** | Score cards, achievement popups, XP bars, combo counters |
-| **Motion** | Bouncy spring physics on everything — text overshoots and settles, screen shakes on impacts |
-| **Accents** | Achievement popup badges, sparkle bursts, "OVER 9000" moments |
-| **Transitions** | Pop cuts, whip pans, bounce effects |
-
-```
-STYLE — PLAY MODE: Neon pink #FF2D78, electric blue #00D4FF, lime green #7FFF00.
-Bouncy spring physics. Score cards, XP bars, achievement popups. Screen shakes on impact.
-Glossy scanline overlay, sparkle particles. Pop cuts, bounce effects.
-```
-
----
 
 ## Avatar Description Guide
 
-Generic avatar descriptions produce generic results. Describe your presenter like a film director describing a character to a cinematographer.
+**The avatar is NOT a fixed headshot** — design it for each video like a movie character. Think costume designer + set designer.
+
+### Thematic Wardrobe Rule
+
+The avatar's outfit and environment MUST match the content's emotional/cultural context:
+
+| Content Type | Avatar Design | NOT This |
+|---|---|---|
+| Chinese New Year | Red qipao with gold embroidery, lantern-lit courtyard | "Reporter in a blazer" |
+| Breaking tech news | Field reporter, windswept hair, earpiece, city skyline | "Anchor at a desk" |
+| Sleep science | Oversized cream knit, cross-legged on bed, warm lamp | "Analyst in a lab" |
+| Reddit community | Messy desk, Reddit alien on monitors, upvote arrows on wall | "Researcher in a studio" |
 
 ### What to Specify
 
-| Element | Generic (Weak) | Specific (Strong) |
-|---------|----------------|-------------------|
-| **Clothing** | "Business casual" | "Black ribbed merino turtleneck, high collar framing jaw" |
-| **Accessories** | "Some jewelry" | "Silver geometric pendant, small hoop earrings, thin silver chain" |
-| **Environment** | "An office" | "Glass-walled conference room. Whiteboard with hand-drawn tier pyramid" |
-| **Desk items** | "A desk" | "Laptop, half-empty flat white, scattered sticky notes" |
-| **Monitor content** | "Computer screens" | "Monitor shows scrolling green terminal text and red security alerts" |
-| **Lighting** | "Well lit" | "Cool blue monitor glow from left, warm amber desk lamp from right" |
+| Element | Weak | Strong |
+|---------|------|--------|
+| Clothing | "Business casual" | "Black ribbed merino turtleneck, high collar framing jaw" |
+| Environment | "An office" | "Glass-walled conference room. Whiteboard with hand-drawn tier pyramid" |
+| Monitor content | "Computer screens" | "Monitor shows scrolling green terminal text and red security alerts" |
+| Lighting | "Well lit" | "Cool blue monitor glow from left, warm amber desk lamp from right" |
 
 ### Template
 
 ```
-AVATAR: [Clothing in detail]. [Accessories]. [Setting description]. [What's on/behind the desk].
-[Monitor content]. [Specific lighting — direction, color, quality]. [Overall mood of the space].
+AVATAR: [Clothing — fabric, color, fit, accessories, posture].
+[Setting — specific props, brand logos, what's on the walls].
+[Monitors/desk — content visible on screens, items on desk].
+[Lighting — direction, color temperature]. [Mood of the space].
+60-100 words. 3+ content-specific props. Brand elements visible.
 ```
 
-### Examples by Tone
-
-**Corporate/Strategic:**
-```
-AVATAR: Navy slim-fit blazer over dark grey crew-neck tee, no tie, sleeves pushed up.
-Glass-walled conference room. Whiteboard behind with hand-drawn framework diagrams.
-Floor-to-ceiling windows, dusk skyline. Table with documents, water glass, blue marker.
-```
-
-**Tech/Editorial:**
-```
-AVATAR: Black leather jacket over dark grey vintage tee with faded circuit board graphic.
-Small silver hoop earrings, thin silver chain. Industrial workspace — dual monitors showing
-Reddit threads and scrolling green terminal text, mechanical keyboard with RGB backlighting,
-scattered neon sticky notes, half-empty energy drink. Exposed brick wall, dim neon sign
-casting warm orange glow. Warm tungsten desk lamp from left, cool monitor glow from behind.
-```
-
-**Premium/Keynote:**
-```
-AVATAR: Tailored black crew-neck sweater — fine-knit merino, subtle texture visible.
-Spacious, architecturally precise room: floor-to-ceiling windows casting diffused natural light,
-polished walnut conference table. A single laptop, closed, and a glass of water. Deep charcoal
-wall with logo etched in matte finish. One recessed spotlight. Every object intentional.
-```
-
----
-
-## Scene Types and Layout
-
-### Three Scene Types
+## Scene Types
 
 | Type | Format | When to Use |
 |------|--------|-------------|
-| **A-ROLL** | Avatar speaking to camera, full frame | Intros, key insights, transitions, CTAs, emotional beats |
-| **FULL SCREEN B-ROLL** | No avatar — motion graphics/visuals only | Data visualization, feature showcases, information-dense content |
-| **A-ROLL + OVERLAY** | Split frame: avatar on one side, content on the other | Presenting data while maintaining human connection |
+| **A-ROLL** | Avatar speaking to camera | Intros, key insights, CTAs, emotional beats |
+| **FULL SCREEN B-ROLL** | No avatar — motion graphics only | Data visualization, information-dense content |
+| **A-ROLL + OVERLAY** | Split frame: avatar + content | Presenting data while maintaining human connection |
 
-### Split Frame Percentages
+**Rotation is mandatory.** Never 3+ of the same type in a row. Every prompt needs at least 2 pure B-roll scenes.
 
-For A-ROLL + OVERLAY scenes, always specify the split:
-
-```
-[SPLIT — Avatar LEFT 35%. Content RIGHT 65%. NO overlap.]
-[SPLIT — Avatar RIGHT 30%. Content LEFT 70%.]
-```
-
-Alternate which side the avatar appears on between overlay scenes to create visual variety.
+**Voiceover on EVERY scene.** Every B-roll scene MUST include a `VOICEOVER:` line. Silent B-roll = broken video.
 
 ### Scene Anatomy
 
-**A-ROLL scene:**
+**A-ROLL:**
 ```
 SCENE 1 — A-ROLL (10s)
 [Avatar center-frame, excited, hands gesturing]
@@ -384,7 +136,7 @@ VOICEOVER: "The exact script for this scene."
 Lower-third: "TITLE TEXT" white on blue bar.
 ```
 
-**B-ROLL scene with visual layers:**
+**B-ROLL with layers:**
 ```
 SCENE 2 — FULL SCREEN B-ROLL (12s)
 [NO AVATAR — motion graphic only]
@@ -393,567 +145,145 @@ LAYER 1: Dark #1a1a1a background with subtle grid lines pulsing.
 LAYER 2: "HEADLINE" SLAMS in from left in white Bold 100pt at -5 degrees.
 LAYER 3: Three data cards CASCADE from right, staggered 0.3s.
 LAYER 4: Bottom ticker SLIDES in: "supporting text scrolling continuously."
-LAYER 5: Grid lines RIPPLE outward from impact point. Scan-line glitch flickers.
+LAYER 5: Grid lines RIPPLE outward from impact point.
 Hard cut.
 ```
 
-**A-ROLL + OVERLAY scene:**
+**A-ROLL + OVERLAY:**
 ```
 SCENE 3 — A-ROLL + OVERLAY (10s)
 [SPLIT — Avatar LEFT 35%. Content RIGHT 65%. NO overlap.]
-Avatar gestures toward content side, impressed expression.
+Avatar gestures toward content side.
 VOICEOVER: "The exact script for this scene."
-RIGHT SIDE: "HEADLINE" in cyan 60pt at top. Three stats COUNT UP below.
-Quote card with border types on at bottom.
+RIGHT SIDE: "HEADLINE" in cyan 60pt. Three stats COUNT UP below.
 ```
 
----
+Alternate which side the avatar appears on between overlay scenes.
 
 ## The Visual Layer System
 
-**This is the most powerful technique for B-roll scenes.** Instead of describing a scene as one visual, break it into 5 layers that stack on top of each other. The Video Agent can interpret each layer independently.
+Break B-roll into 5 stacked layers. This is the most powerful technique for motion graphics scenes.
 
 | Layer | Purpose | Examples |
 |-------|---------|---------|
-| **LAYER 1** | Background | Textured surface, grid, gradient, color field |
-| **LAYER 2** | Hero content | Main headline/number that dominates the frame |
-| **LAYER 3** | Supporting data | Cards, stats, bullet points, secondary information |
-| **LAYER 4** | Information bar | Tickers, labels, source attributions, quotes |
-| **LAYER 5** | Effects | Particles, glitches, grid animations, ambient motion |
+| **L1** | Background | Textured surface, grid, gradient, color field |
+| **L2** | Hero content | Main headline/number that dominates the frame |
+| **L3** | Supporting data | Cards, stats, bullet points, secondary information |
+| **L4** | Information bar | Tickers, labels, source attributions, quotes |
+| **L5** | Effects | Particles, glitches, grid animations, ambient motion |
 
-### Example
-
-```
-LAYER 1: Dark concrete #1a1a1a with industrial scratch textures, subtle scan-line effect.
-LAYER 2: "$141M" SLAMS in from left, white Impact 140pt, fills 40% of frame.
-         "+28% MoM" appears in amber to the right.
-LAYER 3: Three stat cards CASCADE from top-right, staggered 0.3s:
-         "$2.12M New Revenue" — "$3.4M Business ARR" — "$3M Pro ARR."
-         Each number COUNTS UP from 0.
-LAYER 4: Bottom ticker scrolls: "Source: Company Report • Jan 2026 • All-Time Highs"
-LAYER 5: Grid lines RIPPLE outward on the "$141M" slam. Diagonal amber bar
-         (5 degree tilt) behind stat cards. Scan-line glitch at 0.5s and 1.2s marks.
-```
-
----
+Every B-roll: 4+ layers. Every overlay content side: 3+ layers. **Every element must MOVE.**
 
 ## Motion Vocabulary
 
-Use precise verbs to describe how elements enter, move, and exit. Each verb implies a different speed and energy.
-
 ### High Energy
-| Verb | Meaning | Example |
-|------|---------|---------|
-| **SLAMS** | Fast, forceful entrance from an edge | `"$95M" SLAMS in from left at -5 degrees` |
-| **CRASHES** | Even more forceful, with screen shake | `Title CRASHES in from right, screen-shake on impact` |
-| **PUNCHES** | Quick, compact appearance | `Quote card PUNCHES up from bottom` |
-| **STAMPS** | Hard placement, no easing, industrial | `Data blocks STAMP in one after another, staggered 0.4s` |
-| **SMASHES** | Destructive entry | `"85K+" SMASHES in from bottom-left, tilted 12 degrees` |
-| **SHATTERS** | Breaks apart after appearing | `Text SHATTERS after 1.5s, revealing number underneath` |
+| Verb | Example |
+|------|---------|
+| **SLAMS** | `"$95M" SLAMS in from left at -5 degrees` |
+| **CRASHES** | `Title CRASHES in from right, screen-shake on impact` |
+| **PUNCHES** | `Quote card PUNCHES up from bottom` |
+| **STAMPS** | `Data blocks STAMP in staggered 0.4s` |
+| **SHATTERS** | `Text SHATTERS after 1.5s, revealing number underneath` |
 
 ### Medium Energy
-| Verb | Meaning | Example |
-|------|---------|---------|
-| **CASCADE** | Sequential staggered appearance | `Three cards CASCADE from top, staggered 0.3s` |
-| **SLIDES** | Smooth directional movement | `Ticker SLIDES in from right — continuous scroll` |
-| **DROPS** | Falls from above with weight | `"TIER 1" DROPS in with white flash` |
-| **BUILDS** | Constructs progressively | `Pyramid BUILDS bottom-up from blocks` |
-| **FILLS** | Progress bar or area expanding | `Progress bar FILLS 0 to 90% in orange` |
-| **DRAWS** | Line or path tracing itself | `Chart line DRAWS itself left to right` |
+| Verb | Example |
+|------|---------|
+| **CASCADE** | `Three cards CASCADE from top, staggered 0.3s` |
+| **SLIDES** | `Ticker SLIDES in from right — continuous scroll` |
+| **DROPS** | `"TIER 1" DROPS in with white flash` |
+| **FILLS** | `Progress bar FILLS 0 to 90% in orange` |
+| **DRAWS** | `Chart line DRAWS itself left to right` |
 
 ### Low Energy
-| Verb | Meaning | Example |
-|------|---------|---------|
-| **types on** | Letter-by-letter reveal | `Quote types on word by word in italic white` |
-| **fades in** | Gradual opacity increase | `Logo fades in at center, held for 3 seconds` |
-| **FLOATS / DRIFTS** | Gentle, weightless movement | `Bokeh orbs FLOAT across frame at different speeds` |
-| **materializes** | Appears from particles or nothing | `"AVATAR IV" materializes from abstract particles` |
-| **morphs** | Transforms from one shape to another | `Number morphs from 17 to 18.9` |
-| **breathes** | Subtle scale oscillation | `The text breathes — gentle scale oscillation` |
-
-### Counting
-| Verb | Meaning | Example |
-|------|---------|---------|
-| **COUNTS UP** | Animated number incrementing | `"1.85M" COUNTS UP from 0 in amber 96pt` |
-| **counts down** | Animated number decrementing | `Timer COUNTS DOWN from 5:00` |
-
-### Timing Modifiers
-
-Add stagger timing to sequential animations:
-```
-Three cards CASCADE from right, staggered 0.3s
-Five items STAMP in one after another, staggered 0.4s
-```
-
-Add angle modifiers to entries:
-```
-"HEADLINE" SLAMS in from left at -5 degrees, white Impact 100pt
-Title crashes in at +3 degrees, filling 60% of frame
-```
-
----
+| Verb | Example |
+|------|---------|
+| **types on** | `Quote types on word by word in italic white` |
+| **fades in** | `Logo fades in at center, held for 3 seconds` |
+| **FLOATS** | `Bokeh orbs FLOAT across frame at different speeds` |
+| **morphs** | `Number morphs from 17 to 18.9` |
+| **COUNTS UP** | `"1.85M" COUNTS UP from 0 in amber 96pt` |
 
 ## Transition Types
 
-Match your transitions to your visual style:
-
 | Transition | Energy | Styles It Fits |
 |------------|--------|---------------|
-| **Smash cut** | Aggressive | Deconstructed, Maximalist, Carnival Surge |
-| **White flash frame** | Punchy | Deconstructed, Maximalist |
-| **Grid wipe** | Systematic | Swiss Pulse, Digital Grid |
-| **Hard cut** | Clean | Swiss Pulse, Shadow Cut |
-| **Liquid dissolve** | Elegant | Data Drift, Dream State |
-| **Particle dissolve** | Premium | Data Drift |
-| **Slow cross-dissolve** | Refined | Velvet Standard |
-| **Glitch transition** | Raw | Deconstructed |
-| **Clean wipe** | Technical | Digital Grid |
-| **Pop cut / bounce** | Fun | Play Mode, Carnival Surge |
-
-Specify transitions at the end of each scene:
-```
-Smash cut — white flash.
-Grid wipe.
-Liquid dissolve to next scene — colors bleed into each other.
-Hard cut — black frame for 2 frames, then SLAM to next.
-```
-
----
-
-## Critical On-Screen Text
-
-**Always list exact strings that must appear on screen.** This prevents the agent from paraphrasing your data or quotes.
-
-Place this section before your scene-by-scene breakdown:
-
-```
-CRITICAL ON-SCREEN TEXT (display literally):
-- "$141M ARR — All-Time High"
-- "1.85M Signups — +28% MoM"
-- Quote: "Use technology to serve the message, not distract from it." — Shalev Hani
-- "@username" — exact social handle
-- "SOC 2 Type II Certified"
-```
-
-**Why this matters:** Without explicit text, the agent may summarize, round numbers, or rephrase quotes. This section ensures data integrity and brand accuracy.
-
----
-
-## Music and Narration Direction
-
-### Music
-Specify genre, reference artists, and energy arc:
-
-```
-MUSIC: Driving electronic, heavy bass drops on key numbers. Run the Jewels meets
-a tech keynote. Builds relentlessly, only softens for customer stories, then
-hammers back for the close.
-```
-
-```
-MUSIC: Minimal ambient piano with subtle electronic undertones. Nils Frahm meets
-a premium brand film. Elegant, unhurried, building slowly. No drops — just gradual swell.
-```
-
-```
-MUSIC: Upbeat electronic with a driving beat. Tycho meets Bloomberg opening theme.
-Builds through highlights, warms for stories, peaks on close.
-```
-
-### Narration Style
-Add a closing section describing HOW to deliver the voiceover:
-
-```
-NARRATION STYLE: High energy throughout. Let numbers PUNCH — pause before big ones,
-then deliver hard. Customer stories get warmth. Lowlights are fast and honest.
-The close should feel like a mic drop.
-```
-
-```
-NARRATION STYLE: Measured, deliberate. Every word earns its place. Customer stories
-get warmth but not sentimentality. Lowlights delivered with clarity. The close is
-understated — confidence, not bravado.
-```
-
----
+| Smash cut | Aggressive | Deconstructed, Maximalist, Carnival Surge |
+| White flash frame | Punchy | Deconstructed, Maximalist |
+| Grid wipe | Systematic | Swiss Pulse, Digital Grid |
+| Hard cut | Clean | Swiss Pulse, Shadow Cut |
+| Liquid dissolve | Elegant | Data Drift, Dream State |
+| Slow cross-dissolve | Refined | Velvet Standard |
+| Pop cut / bounce | Fun | Play Mode, Carnival Surge |
+| Snap cut | Urgent | Red Wire, Contact Sheet |
+| Soft dissolve | Warm | Soft Signal, Warm Grain, Quiet Drama |
+| Iris wipe | Nostalgic | Heritage Reel |
 
 ## Timing Guidelines
 
-| Content Type | Recommended Duration |
-|--------------|---------------------|
+| Content Type | Duration |
+|--------------|----------|
 | Hook/Intro (A-roll) | 6-10 seconds |
-| Data-heavy B-roll | 10-15 seconds |
+| Data-heavy B-roll | 10-15 seconds (NEVER ≤5s — causes black frames) |
 | A-roll + Overlay | 8-12 seconds |
-| Story/narrative B-roll | 10-12 seconds |
-| Quick transition A-roll | 5-6 seconds |
-| CTA (A-roll) | 6-8 seconds |
-| End Card | 3-5 seconds |
+| CTA / Close (A-roll) | 6-8 seconds |
 
-**Calculating duration from script:** ~150 words/minute speaking pace.
+**Common video lengths:** Social clip: 30-45s (5-7 scenes) | Briefing: 60-75s (7-9 scenes) | Deep dive: 90-120s (10-13 scenes)
 
+**Speaking pace:** ~150 words/minute. Calculate: `words / 150 * 60 = seconds`
+
+## What Doesn't Work
+
+Patterns that consistently produce poor results:
+
+**Layout language** — Screen coordinates cause empty/black B-roll:
 ```
-Words / 150 * 60 = Duration in seconds
-```
-
-**Common video lengths:**
-- Social clip: 30-45 seconds (5-7 scenes)
-- Standard briefing: 60-75 seconds (7-9 scenes)
-- Deep dive: 90-120 seconds (10-13 scenes)
-
----
-
-## Copy Guidelines
-
-Apply these rules to VO scripts and text overlays:
-
-| Rule | Do | Don't |
-|------|-----|-------|
-| Ampersands | Spell out "and" | Use & (except known terms like L&D) |
-| Acronyms | Spell out on first use | Jump straight to acronym |
-| Numbers in VO | Spell out: "one-point-eight-five million" | Say "1.85M" |
-| Numbers on screen | Use figures: "1.85M" | Write out "one point eight five million" |
-| Lists | Use Oxford comma | Skip final comma |
-| Headlines | Sentence case | Title Case Every Word |
-| CTAs | 3-4 words, no punctuation | Long CTAs with periods |
-
-**Length limits:**
-- Headlines: 35-55 characters max
-- Body copy: 20-30 words per section
-- CTAs: 3-4 words max
-- Ticker text: continuous, concise phrases separated by bullets
-
----
-
-## Media Types: When to Use What
-
-| Content Type | Motion Graphics | AI Generated | Stock Media |
-|--------------|:---------------:|:------------:|:-----------:|
-| Data/Statistics | **Best** | - | - |
-| Abstract Concepts | Good | **Best** | - |
-| Real Environments | - | Can work | **Best** |
-| Brand Elements | **Best** | - | - |
-| Human Emotions | - | Uncanny | **Best** |
-| UI/Product Demos | **Best** | - | - |
-| Code/Technical | **Best** | - | - |
-| Futuristic/Conceptual | Good | **Best** | - |
-| Industry Context | - | - | **Best** |
-
-**Production-level prompt rule:** In most cases, motion graphics B-roll with layered text produces more professional results than stock footage or AI-generated imagery. Default to motion graphics unless the scene specifically needs real-world footage or an abstract visual that text can't convey.
-
----
-
-## Using Attachments
-
-Upload files to help Video Agent understand your content:
-
-| Type | Use For |
-|------|---------|
-| Images | Product screenshots, diagrams, brand assets |
-| Videos | Existing footage, demo recordings |
-| PDFs | Training materials, research, product docs |
-| Photos | Your own photo to use as avatar |
-
-**Critical: Always add context** about how attachments should be used:
-
-```
-Use the attached product screenshots as B-roll when discussing features.
-Reference the attached PDF for accurate technical specifications.
-The company logo should appear in the intro and outro.
+❌ "UPPER-LEFT: headline in 48pt Helvetica"
+❌ "CENTER-SCREEN: display at coordinates (400, 300)"
+✅ "135K" SLAMS in from left, white Impact 120pt, fills 40% of frame.
 ```
 
----
-
-## Prompt Complexity Levels
-
-Not every video needs full art direction. Match your prompt depth to your needs:
-
-### Level 1: Quick Prompt (10 seconds to write)
+**Named artists without specs** — "Ikko Tanaka style" means nothing to Video Agent. Translate to concrete rules:
 ```
-Create a 60-second product demo for our AI calendar app.
-Target: busy professionals. Tone: professional but friendly.
-Highlight smart scheduling and time zone handling.
-CTA: Visit our website to start free trial.
+❌ "Use an Ikko Tanaka style"
+✅ "Flat color blocks, maximum 3 colors per frame, 60% negative space, typography as primary element"
 ```
 
-### Level 2: Script-Driven (5 minutes to write)
-Paste your full script with scene type hints. Let Video Agent handle visuals:
+**Style examples injected into prompts** — Full example scenes from a style library confuse the agent. Use the style's **rules**, not example scenes.
 
-```
-Intro (A-roll, motion graphics overlay)
-VO: "If your work is mostly explaining things, video helps — but making it takes too much time."
+**Forced short B-roll (≤5 seconds)** — Too short for rendering. Every tested video with 5s B-roll had empty/black screens. Use 10-15s.
 
-Problem (B-roll motion graphics)
-VO: "Traditional video production requires cameras, editing software, and hours of work."
+**Content as a list, not a story** — "Here are 5 tweets" produces flat videos. Always synthesize: *"X is happening because Y — here's the proof."*
 
-Solution (A-roll)
-VO: "Our platform turns your ideas into production-ready videos in minutes."
+## Production Insights
 
-CTA (A-roll, end beat)
-VO: "Try it free today."
+### Style Performance (from 40+ videos)
 
-End card: [Your Brand] - Make Video Easy
-```
+| Rank | Style | Strength |
+|------|-------|----------|
+| 1 | Deconstructed (Brody) | Most reliable across all topics |
+| 2 | Swiss Pulse (Müller-Brockmann) | Best for data-heavy content |
+| 3 | Digital Grid (Crouwel) | Strong for tech topics |
+| 4 | Geometric Bold (Tanaka) | Elegant and versatile |
+| 5 | Maximalist Type (Scher) | High energy, use sparingly |
 
-### Level 3: Art-Directed (15-30 minutes to write)
-Full FORMAT + STYLE + AVATAR + SCENES + LAYERS. This is what produces broadcast-quality results. See the full example below.
+### Duration by Approach
 
----
+| Approach | Avg Duration | Quality |
+|----------|-------------|---------|
+| Natural storyboard + custom avatar | ~106s | Best |
+| Natural storyboard, no custom avatar | ~69s | Good |
+| Forced short scenes + custom avatar | ~71s | Mixed |
+| Layout language prompts | ~48s | Poor |
 
-## Full Example: Brief to Production Prompt
+## Quality Checklist
 
-### Input Brief
-
-```
-Topic: Monthly company report for a SaaS startup
-Key data: $141M ARR (up from $54M), 1.85M signups (+28%), 3M paid videos/month
-Customer story: Creator built AI character, 2.5M followers, 20 min/video
-Challenge: Organic traffic volatile, -16% last week
-Duration: ~90 seconds
-Tone: Confident CEO, data-backed
-```
-
-### Output Prompt
-
-```
-FORMAT: Bloomberg-style company report. 90 seconds. Fast-paced, data-dense.
-Record-breaking month. Proud but analytical.
-
-TONE: Confident, direct, data-backed. Highlights hit hard with numbers.
-Customer stories are the emotional core. Challenges are honest — no spin.
-
-AVATAR: Man in simple black crew-neck tee, standing in a modern glass-walled
-office at golden hour. Behind him, a wall-mounted display shows the company logo
-in soft blue glow. Monitor to his right shows a dashboard with upward-trending
-charts. Desk beside him: laptop, half-empty flat white, scattered sticky notes.
-Warm afternoon light through floor-to-ceiling windows, long shadows on polished
-concrete. Minimal, focused startup HQ.
-
-STYLE — SWISS PULSE (Muller-Brockmann): Grid-locked compositions. Black (#1a1a1a),
-white, electric blue (#0066FF), warm amber (#FF9500) for records. Helvetica Bold
-headlines, Regular labels. Numbers LARGE. Animated counters count up from 0.
-Diagonal compositions on accent moments. Grid wipe transitions. No dissolves.
-
-CRITICAL ON-SCREEN TEXT (display literally):
-- "1.85M SIGNUPS — +28% MoM"
-- "$2.12M NEW SUBSCRIPTION REVENUE"
-- "$54M → $141M ARR"
-- "2.5M FOLLOWERS" and "20 MIN / VIDEO"
-- Quote: "Use technology to serve the message, not distract from it."
-- "ORGANIC: 65% OF SUBS — VOLATILE"
-
-MUSIC: Upbeat electronic with a driving beat. Tycho meets Bloomberg opening theme.
-Builds through highlights, warms for customer story, softens for challenges, peaks
-on close.
-
----
-
-SCENE 1 — A-ROLL (8s)
-[Avatar center-frame, energetic, leaning slightly forward]
-VOICEOVER: "January was a record month. New highs across acquisition, revenue,
-and product velocity. Here's the full picture."
-Lower-third SLIDES in: "COMPANY NAME | JANUARY 2026" white on blue bar.
-Grid wipe.
-
-SCENE 2 — FULL SCREEN B-ROLL (12s)
-[NO AVATAR — motion graphic only]
-VOICEOVER: "One-point-eight-five million signups — twenty-eight percent month
-over month. Two-point-one-two million in new subscription revenue. Both all-time
-highs."
-LAYER 1: Dark #1a1a1a background with thin grid lines pulsing at 8% opacity.
-LAYER 2: "1.85M" SLAMS in from left, white Bold 140pt. "SIGNUPS" types on
-         in electric blue 32pt uppercase. "+28% MoM" appears in amber.
-LAYER 3: Three stat cards CASCADE from top-right, staggered 0.3s:
-         "$2.12M New Revenue" — "$3.4M Business ARR" — "$3M Pro ARR."
-         Each number COUNTS UP from 0.
-LAYER 4: Bottom ticker scrolls: "Non-brand search +36% • Brand impressions 9.2M
-         • Weekly subs +20.5%"
-LAYER 5: Grid lines RIPPLE outward on "1.85M" slam. Diagonal amber bar behind
-         stat cards.
-Hard cut.
-
-SCENE 3 — FULL SCREEN B-ROLL (12s)
-[NO AVATAR — motion graphic only]
-VOICEOVER: "Zoom out. Twelve months ago — fifty-four million ARR. Today —
-one hundred forty-one million. Nearly three X in a single year."
-LAYER 1: Dark background, subtle grid scrolling upward.
-LAYER 2: Animated line chart DRAWS ITSELF left to right. Y-axis: $50M to $150M.
-         Final point "$140.84M" glows amber and pulses.
-LAYER 3: Milestone annotations float in at key data points.
-LAYER 4: Second smaller chart below — "Paid Videos" 0.91M to 2.97M, same
-         animation style.
-LAYER 5: Thin grid lines converge toward final data point. Scan line sweeps.
-Grid wipe.
-
-SCENE 4 — A-ROLL (8s)
-[Avatar center-frame, warm tone, genuine smile]
-VOICEOVER: "But the numbers only tell half the story. The other half is the
-people building on the platform."
-Lower-third: "Customer Spotlight"
-
-SCENE 5 — FULL SCREEN B-ROLL (12s)
-[NO AVATAR — motion graphic, warm palette]
-VOICEOVER: "An AI character built entirely on the platform. Twenty minutes
-per video. Two-point-five million Instagram followers. The creator's principle:
-use technology to serve the message, not distract from it."
-LAYER 1: Dark background with warm amber grid lines at low opacity.
-LAYER 2: "CHARACTER NAME" in large white, center-top, 80pt.
-LAYER 3: Stats cascade from right: "2.5M Followers" COUNTS UP in amber —
-         "20 min/video" — "7x Faster." Each a glowing node.
-LAYER 4: Quote card SLIDES UP from bottom: "Use technology to serve the
-         message, not distract from it." Types on word by word.
-LAYER 5: Warm light bloom. Grid lines soften into curved arcs.
-Grid wipe.
-
-SCENE 6 — A-ROLL (10s)
-[Avatar center-frame, serious/candid]
-VOICEOVER: "Now the honest part. Organic drives sixty-five percent of
-subscriptions and it's volatile. Non-brand traffic dropped sixteen percent
-last week. We've rebuilt attribution and we're investing in SEO."
-Lower-third: "Challenges"
-
-SCENE 7 — A-ROLL (7s)
-[Avatar center-frame, energy lifts, direct eye contact]
-VOICEOVER: "Fifty-four million to one-forty-one in twelve months. Three million
-paid videos a month. January set the bar — now we raise it."
-End card: Logo centered, blue glow fade-in. Grid lines converge. Music peaks.
-
----
-
-NARRATION STYLE: CEO energy — conviction backed by data. Fast on highlights.
-Warm on customer stories. Candid on challenges. Close with forward momentum,
-not a victory lap.
-```
-
----
-
-## Ready-to-Use Templates
-
-### Tech News Briefing
-```
-FORMAT: 75-second high-energy tech briefing. Think: Bloomberg meets Vice.
-
-AVATAR: [Presenter in tech-casual clothing at a multi-monitor command station.
-Describe clothing, monitors content, desk items, lighting.]
-
-STYLE — DECONSTRUCTED (Neville Brody): Dark grey #1a1a1a, rust orange #D4501E.
-Type at angles, overlapping. Gritty textures. Smash cut transitions.
-
-CRITICAL ON-SCREEN TEXT:
-- [List every stat, quote, handle that must appear]
-
-SCENE 1 — A-ROLL (8s): Hook with energy. State what's happening.
-SCENE 2 — B-ROLL (12s): First story with layered visuals (L1-L5).
-SCENE 3 — A-ROLL + OVERLAY (10s): Second story, split frame.
-SCENE 4 — B-ROLL (10s): Third story or dramatic data point.
-SCENE 5 — A-ROLL (8s): Wrap-up and forward look.
-```
-
-### Product Comparison
-```
-FORMAT: 60-second comparison. [Product A] vs [Product B]. Data-driven.
-
-AVATAR: [Presenter in review studio. Describe desk, monitors showing both products.]
-
-STYLE — DIGITAL GRID (Wim Crouwel): Dark #0a0a0a, cyan #00D4FF and amber #FFB800.
-Two-color coding: cyan = Product A, amber = Product B. Monospaced type.
-
-CRITICAL ON-SCREEN TEXT:
-- [Key stats for each product]
-- [Pricing, features, differentiators]
-
-Use SPLIT FRAME B-roll scenes with Product A data on left, Product B on right.
-```
-
-### Strategy Presentation
-```
-FORMAT: 90-second strategy briefing. Bloomberg meets board meeting.
-
-AVATAR: [Executive in blazer over tee. Conference room with whiteboard frameworks.]
-
-STYLE — SWISS PULSE (Muller-Brockmann): Black/white + blue #0066FF.
-Grid-locked. Helvetica. Animated counters. Grid wipe transitions.
-
-CRITICAL ON-SCREEN TEXT:
-- [Framework labels, axis names, quadrant labels]
-- [Key quotes and data points]
-
-Build frameworks visually: draw axes, plot positions, animate labels.
-```
-
-### Social Ad (30 seconds)
-```
-FORMAT: 30-second social ad. Maximum energy. Portrait 9:16.
-
-AVATAR: [Creator-style presenter. Ring light, colorful background.]
-
-STYLE — CARNIVAL SURGE (Rico Lins): Hot pink, yellow, teal. Collage layering.
-Text MASSIVE at angles. Confetti. Smash cuts.
-
-Three scenes only: Hook (8s) → Value prop (12s) → CTA (10s).
-Text fills 50-80% of every frame. Numbers SLAM.
-```
-
-### Premium Report
-```
-FORMAT: 120-second investor-grade report. Understated authority.
-
-AVATAR: [Tailored merino sweater. Architectural room, diffused natural light.]
-
-STYLE — VELVET STANDARD (Vignelli): Black, white, gold #c9a84c.
-Thin sans-serif, ALL CAPS, wide spacing. Generous negative space.
-Slow cross-dissolves. Let numbers land with weight.
-
-Numbers fade in one at a time. Never crowd the frame.
-```
-
----
-
-## Workflow: Brief to Prompt
-
-When transforming a creative brief into a Video Agent prompt:
-
-1. **Choose a style** — Pick from the Visual Style Library or define your own with colors, type, motion rules, and transitions
-2. **Write the avatar** — Clothing, accessories, environment, monitor content, lighting. Be cinematic
-3. **Extract critical text** — List every number, quote, handle, and label that must appear literally
-4. **Break into scenes** — One concept per scene. Alternate A-roll and B-roll for visual rhythm
-5. **Write voiceover** — Spell out numbers in VO ("one-point-eight-five million"), use figures on screen ("1.85M")
-6. **Layer each B-roll scene** — L1 background, L2 hero, L3 supporting, L4 info bar, L5 effects
-7. **Add music direction** — Reference artists, describe energy arc
-8. **Add narration style** — How to deliver: fast/slow, where to pause, emotional register per section
-
----
-
-## Optimization Checklist
-
-Before submitting your prompt, verify:
-
-- [ ] **Style named** with colors, typography, motion rules, and transitions
-- [ ] **Avatar described** with clothing, environment, lighting, and desk items
-- [ ] **Critical text listed** — every stat, quote, and label that must appear literally
-- [ ] **Scenes alternate** between A-roll and B-roll for visual variety
-- [ ] **B-roll scenes** have 3-5 visual layers (background, hero, supporting, info, effects)
-- [ ] **Split frames** specify percentages and which side the avatar occupies
-- [ ] **Motion verbs** are specific (SLAMS, CASCADE, types on — not "appears")
-- [ ] **Transitions** match the chosen visual style
-- [ ] **VO numbers** are spelled out; **on-screen numbers** use figures
-- [ ] **Duration** is specified per scene in seconds
-- [ ] **Music** has genre, reference artists, and energy arc
-- [ ] **Narration style** describes delivery approach
-
----
-
-## Common Mistakes
-
-| Mistake | Fix |
-|---------|-----|
-| No named visual style | Pick from the library or define your own with colors + type + motion + transitions |
-| Generic avatar: "a person in an office" | Describe clothing fabric, accessories, monitor content, lighting direction |
-| Saying "show some stats" | Use the layer system: L1 background, L2 hero number, L3 supporting cards |
-| Vague motion: "text appears" | Use specific verbs: SLAMS, CASCADE, types on, COUNTS UP |
-| Missing critical text section | List every exact string before the scene breakdown |
-| All A-roll or all B-roll | Alternate scene types for visual rhythm |
-| B-roll with no layers | Every B-roll scene needs at least 3 layers |
-| Same avatar side every overlay | Alternate LEFT/RIGHT between split-frame scenes |
-| Numbers in VO as digits | Spell out in voiceover: "one-point-eight-five million" |
-| No transition specified | End each scene with a transition that matches your style |
-| Forgetting music direction | Add genre, reference artists, and energy arc |
+- [ ] Thesis-driven — story, not bullet points
+- [ ] Style named with colors, typography, motion, transitions (see [visual-styles.md](visual-styles.md))
+- [ ] Avatar has thematic wardrobe + branded environment (60-100 words)
+- [ ] Critical text listed — every stat, quote, label
+- [ ] Scenes rotate types — never 3+ same type. At least 2 B-roll scenes
+- [ ] Every scene has VOICEOVER — including B-roll
+- [ ] B-roll scenes have 4+ layers, every element has motion verbs
+- [ ] B-roll scenes are 10-15 seconds (never ≤5s)
+- [ ] Brand logos appear when discussing companies
+- [ ] Every element moves — no static frames

--- a/skills/heygen/references/visual-styles.md
+++ b/skills/heygen/references/visual-styles.md
@@ -1,0 +1,367 @@
+---
+name: visual-styles
+description: 20 named visual styles for Video Agent prompts — each with colors, typography, motion, and transitions
+---
+
+# Visual Style Library — 20 Styles
+
+Named visual styles for Video Agent prompts. Each is inspired by a real graphic designer. Ordered by mood intensity.
+
+**Picking a style:** Match mood first, content second. Ask: *"What should the viewer FEEL?"*
+
+**Using a style:** Copy the style block into your prompt's STYLE section. Use the visual language rules — don't inject the example B-roll scenes (they confuse the agent).
+
+**Custom styles:** These are examples. Create your own by combining elements, referencing other designers, art movements, or cultural aesthetics. The pattern: **named style + designer reference + color palette + typography + motion rules + transitions.**
+
+## Quick Reference
+
+| # | Style | Artist | Mood | Best For |
+|---|---|---|---|---|
+| 1 | Soft Signal | Sagmeister | Intimate, warm | Personal stories, wellness |
+| 2 | Warm Grain | Eksell | Organic, friendly | Environmental, sustainability |
+| 3 | Quiet Drama | Ray | Humanist, contemplative | Profiles, biographical |
+| 4 | Heritage Reel | Cassandre | Nostalgic, vintage | History, retrospectives |
+| 5 | Silk Route | Abedini | Flowing, mysterious | Global affairs, cross-cultural |
+| 6 | Swiss Pulse | Müller-Brockmann | Clinical, precise | Data-heavy, analytical |
+| 7 | Geometric Bold | Tanaka | Minimal, elegant | Lifestyle, visual essays |
+| 8 | Velvet Standard | Vignelli | Premium, timeless | Luxury, investor updates |
+| 9 | Digital Grid | Crouwel | Systematic, technical | Infrastructure, engineering |
+| 10 | Contact Sheet | Brodovitch | Editorial, investigative | Journalism, deep dives |
+| 11 | Folk Frequency | Terrazas | Cultural, vivid | Festivals, food, heritage |
+| 12 | Earth Pulse | Ghariokwu | Grounded, communal | Community, grassroots |
+| 13 | Dream State | Tomaszewski | Surreal, poetic | Op-eds, philosophy |
+| 14 | Play Mode | Ahn Sang-soo | Playful, irreverent | Entertainment, pop culture |
+| 15 | Carnival Surge | Lins | Euphoric, celebratory | Milestones, hype |
+| 16 | Shadow Cut | Hillmann | Dark, cinematic | Exposés, investigations |
+| 17 | Deconstructed | Brody | Industrial, raw | Tech news, punk energy |
+| 18 | Maximalist Type | Scher | Loud, kinetic | Big announcements, launches |
+| 19 | Data Drift | Anadol | Futuristic, immersive | AI/tech, innovation |
+| 20 | Red Wire | Tartakover | Urgent, immediate | Breaking news, crisis |
+
+## Mood-to-Style Guide
+
+| Content feels... | Use... |
+|---|---|
+| Personal, intimate | Soft Signal, Quiet Drama |
+| Natural, earthy | Warm Grain, Earth Pulse |
+| Nostalgic, historical | Heritage Reel |
+| Data-driven, analytical | Swiss Pulse, Digital Grid |
+| Elegant, premium | Velvet Standard, Geometric Bold |
+| Cultural, global | Silk Route, Folk Frequency |
+| Investigative, serious | Contact Sheet, Shadow Cut |
+| Fun, lighthearted | Play Mode, Carnival Surge |
+| Philosophical, abstract | Dream State |
+| Punk, grassroots, raw | Deconstructed |
+| Hype, loud, high-energy | Maximalist Type |
+| Tech-forward, futuristic | Data Drift |
+| Breaking, urgent | Red Wire |
+
+---
+
+## 1. Soft Signal — Stefan Sagmeister
+
+**Mood:** Intimate, warm | **Best for:** Personal stories, wellness, reflections
+
+- Warm amber and cream with dusty rose, sage green, honey gold accents
+- Handwritten-style text overlays — personal, lowercase, delicate
+- Close-up framing: hands, faces, textures. Macro lens feel
+- Slow drifts and floats, never snaps. Soft dissolves, warm light leaks
+
+```
+STYLE — SOFT SIGNAL (Sagmeister): Warm amber/cream, dusty rose, sage green.
+Handwritten-style text. Close-up framing. Slow drifts and floats.
+Soft dissolves with warm light leaks.
+```
+
+## 2. Warm Grain — Olle Eksell
+
+**Mood:** Organic, friendly | **Best for:** Environmental, sustainability, community
+
+- Earth tones: ochre, forest green, terracotta, cream, soft brown
+- Rounded sans-serif type. Organic rounded compositions — nothing angular
+- 16mm film grain, slightly desaturated. Natural textures: wood, linen, stone
+- Gentle wipes, soft cuts, unhurried
+
+```
+STYLE — WARM GRAIN (Eksell): Earth tones — ochre, forest green, terracotta, cream.
+Organic rounded compositions. 16mm film grain. Rounded sans-serif.
+Gentle wipes and soft cuts.
+```
+
+## 3. Quiet Drama — Satyajit Ray
+
+**Mood:** Humanist, contemplative | **Best for:** Profiles, biographical, cultural
+
+- Muted warm: sepia, deep brown, soft gold, off-white, charcoal
+- Clean serif type, positioned with care. Portrait framing
+- Strong single-source contrast: window light, single lamp
+- Deliberate pacing, longer holds. Slow fades to black
+
+```
+STYLE — QUIET DRAMA (Ray): Muted warm — sepia, deep brown, soft gold.
+Portrait framing. Clean serif. Strong single-source contrast.
+Slow fades to black.
+```
+
+## 4. Heritage Reel — Cassandre
+
+**Mood:** Nostalgic, vintage | **Best for:** History, retrospectives, brand origins
+
+- Faded gold, deep burgundy, navy, cream, sepia wash
+- Elegant centered serif like classic film title cards
+- Vignetting, softened edges. Film grain, light scratches, gentle jitter
+- Iris wipes, film reel flicker
+
+```
+STYLE — HERITAGE REEL (Cassandre): Faded gold, burgundy, navy, sepia wash.
+Elegant centered serif. Vignetting and aged film grain.
+Iris wipe transitions.
+```
+
+## 5. Silk Route — Reza Abedini
+
+**Mood:** Flowing, mysterious | **Best for:** Global affairs, cross-cultural, art/design
+
+- Rich jewel tones: deep teal, burgundy, gold, lapis blue, black
+- Elegant spaced type along natural visual lines
+- Layered compositions — foreground, midground, background all active
+- Flowing dissolves, smooth morphs
+
+```
+STYLE — SILK ROUTE (Abedini): Jewel tones — deep teal, burgundy, gold, lapis blue.
+Layered compositions, all depths active. Elegant spaced type.
+Flowing dissolves and smooth morphs.
+```
+
+## 6. Swiss Pulse — Josef Müller-Brockmann
+
+**Mood:** Clinical, precise | **Best for:** Data-heavy, analytical, financial, metrics
+
+- Black (#1a1a1a), white, ONE accent: electric blue (#0066FF)
+- Helvetica Bold headlines, Regular labels. Numbers LARGE (80-120pt)
+- Grid-locked compositions. Every element snaps to 12-column grid
+- Animated counters COUNT UP from 0. Diagonal compositions on key moments
+- Grid wipes, hard cuts. No dissolves
+
+```
+STYLE — SWISS PULSE (Müller-Brockmann): Black/white + electric blue #0066FF.
+Grid-locked. Helvetica Bold. Animated counters. Diagonal accents.
+Grid wipe transitions.
+```
+
+## 7. Geometric Bold — Ikko Tanaka
+
+**Mood:** Minimal, elegant | **Best for:** Clean lifestyle, culture, visual essays, brand profiles
+
+- Maximum 3 flat colors per frame — no gradients
+- Bold clean type as primary visual element
+- Asymmetric composition, 60% negative space minimum. Single focal point
+- Clean cuts on beat, no effects
+
+```
+STYLE — GEOMETRIC BOLD (Tanaka): Max 3 flat colors per frame.
+60% negative space. Bold type as primary element.
+Single focal point. Clean cuts on beat.
+```
+
+## 8. Velvet Standard — Massimo Vignelli
+
+**Mood:** Premium, timeless | **Best for:** Luxury, investor updates, keynotes, product showcases
+
+- Black, white, ONE rich accent: deep navy (#1a237e) or gold (#c9a84c)
+- Thin sans-serif, ALL CAPS, letter-spaced wide
+- Generous negative space. Symmetrical, centered, architectural precision
+- Slow, deliberate. Sequential reveals. Elegant cross-dissolves
+
+```
+STYLE — VELVET STANDARD (Vignelli): Black, white, one accent: gold #c9a84c.
+Thin ALL CAPS, wide spacing. Generous negative space.
+Slow elegant cross-dissolves.
+```
+
+## 9. Digital Grid — Wim Crouwel
+
+**Mood:** Systematic, technical | **Best for:** Infrastructure, engineering, code, tech
+
+- Dark (#0a0a0a) with cyan (#00E5FF), amber (#FFB300), green (#00FF88)
+- Monospaced type throughout. Code-terminal aesthetic
+- Pixel grid overlays visible. Everything snaps to system
+- Grid nodes light up sequentially. Scan-line effects, cursor blinks
+- Clean wipe transitions
+
+```
+STYLE — DIGITAL GRID (Crouwel): Monospaced type. Dark #0a0a0a with cyan #00E5FF, amber #FFB300.
+Pixel grid overlays. Terminal aesthetic. Clean wipe transitions.
+```
+
+## 10. Contact Sheet — Alexey Brodovitch
+
+**Mood:** Editorial, investigative | **Best for:** Journalism, deep dives, research breakdowns
+
+- High contrast B&W with occasional desaturated color accents
+- Bold sans-serif captions like editorial annotations
+- Photo-editorial framing — multiple images, contact-sheet energy
+- Raw grain, imperfect focus. Tight crops on faces and hands
+- Hard cuts on beat, snap-zooms
+
+```
+STYLE — CONTACT SHEET (Brodovitch): High contrast B&W, desaturated accents.
+Photo-editorial framing. Bold sans-serif annotations. Raw grain.
+Hard cuts on beat. Snap-zooms.
+```
+
+## 11. Folk Frequency — Eduardo Terrazas
+
+**Mood:** Cultural, vivid | **Best for:** Cultural events, food, tradition, heritage
+
+- Vivid folk: hot pink, bright orange, cobalt blue, sun yellow, emerald
+- Bold warm rounded type. Pattern and repetition — folk art rhythms
+- Rich textures: woven fabrics, painted surfaces, ceramic, handmade
+- Colorful wipes, quick cuts on festive rhythm
+
+```
+STYLE — FOLK FREQUENCY (Terrazas): Vivid folk — hot pink, cobalt blue, sun yellow, emerald.
+Bold rounded type. Folk art rhythms. Rich handmade textures.
+Colorful wipes on festive rhythm.
+```
+
+## 12. Earth Pulse — Lemi Ghariokwu
+
+**Mood:** Grounded, communal | **Best for:** Community, music/culture, grassroots
+
+- Warm saturated: burnt orange, deep green, rich yellow, terracotta
+- Bold expressive type, center-frame. Wide community framing
+- Rhythmic editing timed to musical beats
+- Rhythmic cuts on beat, freeze-frames for emphasis
+
+```
+STYLE — EARTH PULSE (Ghariokwu): Warm saturated — burnt orange, deep green, rich yellow.
+Bold expressive type. Wide community framing.
+Rhythmic cuts on beat. Freeze-frames.
+```
+
+## 13. Dream State — Henryk Tomaszewski
+
+**Mood:** Surreal, poetic | **Best for:** Op-eds, philosophy, think pieces, speculative
+
+- Muted palette with one surreal accent: dusty blues, grey-greens, then shock of red or gold
+- Sparse precise text — few words, maximum impact. Thin elegant floating type
+- Unusual juxtapositions. Dreamlike quality: soft edges, atmospheric haze
+- Slow morph dissolves. NEVER hard cuts
+
+```
+STYLE — DREAM STATE (Tomaszewski): Muted palette + one surreal accent.
+Thin elegant floating type. Soft edges, atmospheric haze.
+Slow morph dissolves — NEVER hard cuts.
+```
+
+## 14. Play Mode — Ahn Sang-soo
+
+**Mood:** Playful, irreverent | **Best for:** Entertainment, pop culture, listicles, fun
+
+- Bright candy: electric blue, hot pink, lime green, yellow, white
+- Bouncy oversized tilted text. Asymmetric off-kilter compositions
+- Quick cuts (1-3 seconds). Score cards, achievement popups, XP bars
+- Bouncy spring physics — text overshoots and settles, screen shakes
+- Pop cuts, whip pans, bounce effects
+
+```
+STYLE — PLAY MODE (Ahn Sang-soo): Electric blue, hot pink, lime green.
+Bouncy spring physics. Oversized tilted text. Score cards, XP bars.
+Pop cuts, bounce effects.
+```
+
+## 15. Carnival Surge — Rico Lins
+
+**Mood:** Euphoric, celebratory | **Best for:** Big announcements, milestones, celebrations, hype
+
+- Maximum color: hot pink (#FF1493), electric yellow (#FFE000), teal (#00CED1), orange, violet
+- MASSIVE bold text at ANGLES over footage. Collage-style overlapping
+- Rapid 1-2 second clips. Confetti, lights, constant energy
+- Smash cuts, flash frames, rapid-fire montage
+
+```
+STYLE — CARNIVAL SURGE (Lins): Max color — hot pink #FF1493, yellow #FFE000, teal #00CED1.
+Collage layering. Text MASSIVE at ANGLES. Confetti bursts.
+Smash cuts, flash frames.
+```
+
+## 16. Shadow Cut — Hans Hillmann
+
+**Mood:** Dark, cinematic | **Best for:** Exposés, investigations, controversy, dark deep dives
+
+- Near-monochrome: deep blacks, cold greys, stark white + blood red or toxic green
+- Sharp angular text like film noir title cards
+- Heavy shadow — faces half-lit, objects emerging from darkness
+- Slow creeping push-ins, slow reveals, tension
+- Iris to black, slow fade from darkness, hard cuts to silence
+
+```
+STYLE — SHADOW CUT (Hillmann): Deep blacks, cold greys + blood red accent.
+Sharp angular text. Heavy shadow. Slow creeping push-ins.
+Hard cuts to black. Film noir tension.
+```
+
+## 17. Deconstructed — Neville Brody
+
+**Mood:** Industrial, raw | **Best for:** Tech news, security, punk energy, counter-culture
+
+- Dark grey (#1a1a1a), black, rust orange (#D4501E), raw white (#f0f0f0)
+- Type at angles, overlapping edges, escaping frames. Bold industrial
+- High contrast, gritty textures: scratched metal, peeling paint, scan-line glitch
+- Text SLAMS, SHATTERS, PUNCHES. Letters scramble then snap
+- Smash cuts, glitch transitions, white flash frames
+
+```
+STYLE — DECONSTRUCTED (Brody): Dark grey #1a1a1a, rust orange #D4501E.
+Type at angles, overlapping. Gritty textures, scan-line glitch.
+Smash cuts with flash frames.
+```
+
+## 18. Maximalist Type — Paula Scher
+
+**Mood:** Loud, kinetic | **Best for:** Big announcements, launches, high-energy recaps
+
+- Bold saturated: red, yellow, black, white — maximum contrast
+- Text IS the visual. Overlapping layers at different scales and angles, 50-80% of frame
+- Kinetic energy: everything moving, slamming, sliding. 1-2 second rapid cuts
+- Text layered OVER footage — never empty backgrounds
+- Smash cuts, text slamming from edges, flash frames
+
+```
+STYLE — MAXIMALIST TYPE (Scher): Red, yellow, black, white — max contrast.
+Text IS the visual. Overlapping at different scales, 50-80% of frame.
+Kinetic everything. Smash cuts, flash frames.
+```
+
+## 19. Data Drift — Refik Anadol
+
+**Mood:** Futuristic, immersive | **Best for:** AI/tech, speculative, cutting-edge science
+
+- Iridescent: holographic silver, electric purple (#7c3aed), cyan (#06b6d4), deep black (#0a0a0a)
+- Thin futuristic sans-serif — minimal, floating, weightless
+- Fluid morphing compositions. Extreme scale shifts: microscopic to cosmic
+- Particles coalesce into numbers, light traces data paths
+- Liquid dissolves, particles dispersing and reforming
+
+```
+STYLE — DATA DRIFT (Anadol): Iridescent — purple #7c3aed, cyan #06b6d4, deep black.
+Fluid morphing compositions. Thin futuristic type.
+Liquid dissolves. Particles coalesce into numbers.
+```
+
+## 20. Red Wire — David Tartakover
+
+**Mood:** Urgent, immediate | **Best for:** Breaking news, crisis updates, alerts
+
+- High alert: red, black, white, emergency yellow — maximum contrast
+- Bold condensed all caps — every word screams urgency
+- Split screens, ticker-style text bars, timestamp overlays — max information density
+- Multiple text elements simultaneously. Handheld energy
+- Snap cuts, flash frames, zero breathing room
+
+```
+STYLE — RED WIRE (Tartakover): Red, black, white, emergency yellow.
+Bold condensed all-caps. Split screens, tickers, timestamps.
+Snap cuts, flash frames. Zero breathing room.
+```


### PR DESCRIPTION
## Summary

Restructures the prompt-optimizer skill following [skill-creator](https://skills.sh/anthropics/skills/skill-creator) best practices and incorporates insights from the [beacon-signal](https://github.com/heybeaconhq/beacon-signal) public skill (same power user whose patterns informed v2).

### Structure (progressive disclosure)
- **`prompt-optimizer.md`** (289 lines) — Core workflow, prompt anatomy, scene types, layer system, motion vocab, anti-patterns, production insights
- **`visual-styles.md`** (367 lines) — 20 named styles with full specs, mood-to-style guide. Loaded only when choosing a style
- **`prompt-examples.md`** (206 lines) — Full production example + 5 ready-to-use templates. Loaded only when writing a prompt from scratch

Previously this was a single 1321-line file.

### Added from beacon-signal
- 10 new visual styles (Soft Signal, Warm Grain, Quiet Drama, Heritage Reel, Silk Route, Geometric Bold, Contact Sheet, Folk Frequency, Earth Pulse, Red Wire)
- Anti-patterns from 40+ production videos (layout language, forced short B-roll, named artists without specs)
- Style performance rankings and duration-by-approach data
- Thematic wardrobe requirement, thesis-driven narrative, scene rotation enforcement

### Removed (generic/obvious to Claude)
- Copy Guidelines (Oxford commas, sentence case, ampersands)
- Media Types table
- Using Attachments section
- Prompt Complexity Levels 1 & 2

## Test plan
- [ ] Verify prompt-optimizer.md loads cleanly and references visual-styles.md and prompt-examples.md
- [ ] Verify each style in visual-styles.md has a copyable style block
- [ ] Test generating a video using the new workflow to confirm quality hasn't regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)