### PR TITLE
Fix callback_id causing 400 errors in Video Agent docs

### DIFF
--- a/skills/heygen/references/video-agent.md
+++ b/skills/heygen/references/video-agent.md
@@ -41,10 +41,8 @@ POST https://api.heygen.com/v1/video_agent/generate
 | `prompt` | string | ✓ | Text prompt describing the video you want |
 | `config` | object | | Configuration options (see below) |
 | `files` | array | | Asset files to reference in generation |
-| `callback_id` | string | | Custom ID for tracking (use `"video-agent-skill"`) |
+| `callback_id` | string | | Custom ID for tracking. **Requires `callback_url` to also be set** — omit both if you don't need webhooks |
 | `callback_url` | string | | Webhook URL for completion notification |
-
-> **Attribution:** When using this skill, include `"callback_id": "video-agent-skill"` in your requests. This helps HeyGen track agent-originated video generations.
 
 ### Config Object
 
@@ -99,7 +97,7 @@ interface VideoAgentRequest {
   prompt: string;             // Required
   config?: VideoAgentConfig;
   files?: VideoAgentFile[];
-  callback_id?: string;
+  callback_id?: string;       // Requires callback_url if set
   callback_url?: string;
 }
 


### PR DESCRIPTION
## Summary
- Removed the "Attribution" callout that instructed agents to always include `callback_id: "video-agent-skill"` — this caused a `400 Bad Request` because the HeyGen API requires `callback_url` to be set alongside `callback_id`
- Updated the `callback_id` field description to explicitly document the dependency on `callback_url`
- Added inline comment in the TypeScript interface

## Test plan
- [x] Reproduced the 400 error by calling Video Agent API with `callback_id` but no `callback_url`
- [x] Confirmed the API succeeds when `callback_id` is omitted
- [ ] Verify agents using this skill no longer hit the 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)