### PR TITLE
Split into multi-skill repo: heygen, text-to-speech, video-translate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "heygen-skills",
+  "owner": {
+    "name": "HeyGen",
+    "url": "https://heygen.com"
+  },
+  "plugins": [
+    {
+      "name": "heygen",
+      "source": "./",
+      "description": "Claude Skills for HeyGen AI video creation, text-to-speech, and video translation",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "heygen",
+  "version": "1.0.0",
+  "description": "Create AI avatar videos, generate speech audio, and translate videos with the HeyGen API.",
+  "author": {
+    "name": "HeyGen",
+    "url": "https://heygen.com"
+  },
+  "repository": "https://github.com/heygen-com/skills",
+  "license": "MIT",
+  "keywords": [
+    "heygen",
+    "video",
+    "avatar",
+    "ai",
+    "text-to-speech",
+    "tts",
+    "video-translation",
+    "text-to-video",
+    "talking-head"
+  ]
+}

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -23,11 +23,29 @@ jobs:
       - name: Login to ClawHub
         run: clawhub login --token "${{ secrets.CLAWHUB_TOKEN }}" --no-browser
 
-      - name: Publish to ClawHub
+      - name: Publish heygen skill
         run: |
           clawhub publish ./skills/heygen \
             --slug video-agent \
             --name "Video Agent" \
             --version 2.${{ github.run_number }}.0 \
             --tags latest,video,heygen,ai-avatar,text-to-video,talking-head,video-generation,avatar,ai-video,digital-human \
+            --changelog "Auto-publish from commit ${{ github.sha }}"
+
+      - name: Publish text-to-speech skill
+        run: |
+          clawhub publish ./skills/text-to-speech \
+            --slug text-to-speech \
+            --name "Text to Speech" \
+            --version 2.${{ github.run_number }}.0 \
+            --tags latest,tts,text-to-speech,heygen,audio,voice,speech,starfish \
+            --changelog "Auto-publish from commit ${{ github.sha }}"
+
+      - name: Publish video-translate skill
+        run: |
+          clawhub publish ./skills/video-translate \
+            --slug video-translate \
+            --name "Video Translate" \
+            --version 2.${{ github.run_number }}.0 \
+            --tags latest,translation,dubbing,heygen,video-translate,localization,lip-sync \
             --changelog "Auto-publish from commit ${{ github.sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+This repo contains Claude Code skills for the HeyGen AI video creation API. It is a multi-skill repository distributed via three channels: Claude Code plugin marketplace, Vercel skills.sh (`npx skills add`), and ClawHub.
+
+## Project Structure
+
+```
+heygen-skills/
+├── skills/
+│   ├── heygen/                      # Video creation (main skill)
+│   │   ├── SKILL.md                 # Skill manifest + routing table
+│   │   └── references/              # On-demand reference docs
+│   ├── text-to-speech/              # Standalone TTS audio
+│   │   └── SKILL.md                 # Self-contained (no references/)
+│   └── video-translate/             # Video translation & dubbing
+│       └── SKILL.md                 # Self-contained (no references/)
+├── .claude-plugin/
+│   ├── plugin.json                  # Claude Code plugin manifest
+│   └── marketplace.json             # Marketplace listing
+├── .github/workflows/
+│   └── publish-clawhub.yml          # CI: publishes all skills to ClawHub
+├── README.md
+└── CLAUDE.md                        # This file
+```
+
+## Skill Architecture
+
+### Design Principles
+
+1. **Each skill is self-contained.** No cross-skill dependencies. Skills must not reference files in sibling skill directories.
+2. **Split by distinct user intent and output type.** A new skill is warranted when it has a different output type (audio vs video), different API surface, and can stand alone.
+3. **The `heygen` skill is the main skill.** It covers video creation (Video Agent + v2 API), avatars, voices, backgrounds, captions, prompts, and Remotion integration. Shared concepts like avatars and voices live here.
+4. **Smaller skills inline everything.** `text-to-speech` and `video-translate` have no `references/` directory — all content is in SKILL.md. Only split into references when SKILL.md would exceed ~500 lines.
+5. **Auth is inlined per skill.** Each skill includes a brief authentication section rather than referencing a shared auth file.
+
+### Naming Conventions
+
+- **Skill directory names**: lowercase, hyphens (e.g., `text-to-speech`, `video-translate`)
+- **Skill `name` in frontmatter**: matches directory name exactly
+- **Generic names, not product-prefixed**: use `text-to-speech` not `heygen-tts`. The plugin namespace handles branding (`heygen:text-to-speech`).
+- **ClawHub slugs**: match the skill name where possible (e.g., `video-agent`, `text-to-speech`, `video-translate`)
+
+### SKILL.md Format
+
+Every SKILL.md follows this structure:
+
+```yaml
+---
+name: skill-name
+description: |
+  One-line summary. Use when: (1) first trigger, (2) second trigger, (3) etc.
+allowed-tools: mcp__heygen__*
+metadata:
+  openclaw:
+    requires:
+      env:
+        - HEYGEN_API_KEY
+    primaryEnv: HEYGEN_API_KEY
+---
+
+# Skill Title
+
+Brief intro paragraph.
+
+## Authentication
+(inline, 3-5 lines)
+
+## Tool Selection
+(MCP tools table if applicable)
+
+## Default Workflow
+(numbered steps)
+
+## [API-specific sections]
+(endpoints, request/response, TypeScript + Python examples)
+
+## Best Practices
+(numbered list)
+```
+
+### Description Guidelines
+
+Descriptions must be **trigger-rich** — include explicit "Use when:" clauses with specific scenarios. This drives Claude's skill selection accuracy. Example:
+
+```
+Generate speech audio from text using HeyGen's Starfish TTS model. Use when: (1) Generating standalone speech audio files from text, (2) Converting text to speech with voice selection, speed, pitch, and emotion control, ...
+```
+
+## Adding a New Skill
+
+1. Create `skills/<skill-name>/SKILL.md` following the format above
+2. Include inline auth section (copy the 3-line pattern from an existing skill)
+3. Include curl, TypeScript, and Python examples for each endpoint
+4. Add the skill to the README.md skills table
+5. Add a publish step in `.github/workflows/publish-clawhub.yml`
+6. Update `.claude-plugin/plugin.json` description if the overall plugin scope changed
+7. Do NOT add cross-references to other skills — each skill must stand alone
+
+## Updating Existing Skills
+
+- **API changes**: Update the affected SKILL.md and/or reference files. If a change affects auth or shared patterns, update it in EVERY skill that inlines it.
+- **Adding a reference file**: Only for the `heygen` skill. Add the file to `references/`, then add a link in the SKILL.md Reference Files section.
+- **Smaller skills** (`text-to-speech`, `video-translate`): Edit SKILL.md directly. Only create a `references/` directory if SKILL.md would exceed ~500 lines.
+
+## Distribution
+
+Three channels, one repo:
+
+| Channel | Mechanism | What it reads |
+|---------|-----------|---------------|
+| Claude Code plugins | `/plugin install heygen@heygen-skills` | `.claude-plugin/` manifests |
+| Vercel skills.sh | `npx skills add heygen-com/skills` | `skills/*/SKILL.md` auto-discovery |
+| ClawHub | CI publishes on merge to master | `.github/workflows/publish-clawhub.yml` |
+
+## HeyGen API Conventions
+
+- Base URL: `https://api.heygen.com`
+- Auth header: `X-Api-Key: $HEYGEN_API_KEY`
+- Response format: `{ "error": null | string, "data": T }`
+- Video generation is async: generate returns `video_id`, poll `GET /v1/video_status.get` for completion
+- MCP tools (`mcp__heygen__*`) are preferred over direct API calls when available

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 # HeyGen Skills for Claude Code
 
-A knowledge base of best practices and API documentation for working with the HeyGen AI avatar video creation API, designed for use with Claude Code.
+A collection of skills for working with the HeyGen AI video creation API, designed for use with Claude Code and other skills-compatible agents.
 
-## Overview
+## Skills
 
-This skills package provides Claude Code with domain-specific knowledge about the HeyGen API, enabling it to:
-
-- Generate AI avatar videos with precise control (v2 API)
-- Create videos from simple prompts using Video Agent
-- Optimize prompts for better Video Agent results
-- Work with avatars, voices, and backgrounds
-- Handle video translation and dubbing
-- Manage streaming avatars for real-time interaction
-- Create photo avatars (talking photos)
-- Integrate with Remotion for programmatic video composition
-- Configure webhooks and callbacks
+| Skill | Description |
+|-------|-------------|
+| [heygen](skills/heygen) | Create AI avatar videos with Video Agent or precise v2 API control. Covers avatars, voices, backgrounds, captions, prompts, and Remotion integration |
+| [text-to-speech](skills/text-to-speech) | Generate standalone speech audio from text using HeyGen's Starfish TTS model with voice, speed, pitch, and emotion control |
+| [video-translate](skills/video-translate) | Translate and dub existing videos into 12+ languages with lip-sync, voice cloning, and multi-speaker support |
 
 ## Installation
 
-### Option 1: Using add-skill CLI (Recommended)
-
-Install using the [add-skill](https://github.com/vercel-labs/add-skill) CLI:
+### Option 1: Claude Code Plugin Marketplace
 
 ```bash
-# Install to Claude Code globally
+/plugin marketplace add heygen-com/skills
+/plugin install heygen@heygen-skills
+```
+
+### Option 2: Using add-skill CLI (Recommended for multi-agent)
+
+Install using the [skills](https://github.com/vercel-labs/skills) CLI:
+
+```bash
+# Install all skills globally
 npx skills add heygen-com/skills -a claude-code -g
 
 # Or install to current project only
@@ -31,11 +32,14 @@ npx skills add heygen-com/skills -a claude-code
 
 # List available skills first
 npx skills add heygen-com/skills --list
+
+# Install a specific skill only
+npx skills add heygen-com/skills --skill text-to-speech
 ```
 
-This works with Claude Code, Cursor, Codex, and [13 other agents](https://github.com/vercel-labs/add-skill#available-agents).
+This works with Claude Code, Cursor, Codex, and [other agents](https://github.com/vercel-labs/skills#available-agents).
 
-### Option 2: Manual Installation
+### Option 3: Manual Installation
 
 Clone and symlink to your Claude skills directory:
 
@@ -43,132 +47,81 @@ Clone and symlink to your Claude skills directory:
 # Clone the repository
 git clone https://github.com/heygen-com/skills.git
 
-# Symlink to personal skills (available in all projects)
-ln -s $(pwd)/skills/skills/heygen ~/.claude/skills/heygen
+# Symlink all skills to personal skills directory (available in all projects)
+for skill in skills/skills/*/; do
+  ln -s "$(pwd)/$skill" ~/.claude/skills/$(basename "$skill")
+done
 
 # OR symlink to project skills (available in current project only)
 mkdir -p .claude/skills
-ln -s $(pwd)/skills/skills/heygen .claude/skills/heygen
-```
-
-### Option 3: Direct Copy
-
-Copy the skill directly to your project:
-
-```bash
-git clone https://github.com/heygen-com/skills.git
-mkdir -p .claude/skills
-cp -r skills/skills/heygen .claude/skills/
+for skill in skills/skills/*/; do
+  ln -s "$(pwd)/$skill" .claude/skills/$(basename "$skill")
+done
 ```
 
 ### Verify Installation
 
-The skill should appear when Claude Code loads. You can verify by asking Claude about HeyGen APIs.
+The skills should appear when Claude Code loads. You can verify by asking Claude about HeyGen APIs.
 
 ## Quick Reference
 
-| Task | Reference Files |
-|------|-----------------|
-| Generate video from prompt (easy) | [prompt-optimizer.md](skills/heygen/references/prompt-optimizer.md) → [video-agent.md](skills/heygen/references/video-agent.md) |
-| Generate video with precise control | [video-generation.md](skills/heygen/references/video-generation.md), [avatars.md](skills/heygen/references/avatars.md), [voices.md](skills/heygen/references/voices.md) |
-| Check video status / get download URL | [video-status.md](skills/heygen/references/video-status.md) |
-| Add captions or text overlays | [captions.md](skills/heygen/references/captions.md), [text-overlays.md](skills/heygen/references/text-overlays.md) |
-| Transparent video for compositing | [video-generation.md](skills/heygen/references/video-generation.md) (WebM section) |
-| Real-time interactive avatar | [streaming-avatars.md](skills/heygen/references/streaming-avatars.md) |
-| Translate/dub existing video | [video-translation.md](skills/heygen/references/video-translation.md) |
-| Use with Remotion | [remotion-integration.md](skills/heygen/references/remotion-integration.md) |
+| Task | Skill |
+|------|-------|
+| Generate video from a prompt | `heygen` |
+| Generate video with precise scene control | `heygen` |
+| List avatars and voices | `heygen` |
+| Generate speech audio from text | `text-to-speech` |
+| List TTS voices | `text-to-speech` |
+| Translate/dub an existing video | `video-translate` |
+| Batch translate to multiple languages | `video-translate` |
 
-## Contents
-
-### Foundation
-- **authentication.md** - API key setup and X-Api-Key header
-- **quota.md** - Credit system and usage limits
-- **video-status.md** - Polling patterns and download URLs
-- **assets.md** - Uploading images, videos, audio
-
-### Core Video Creation
-- **avatars.md** - Listing avatars, styles, avatar_id selection
-- **voices.md** - Voice configuration, locales, speed/pitch
-- **scripts.md** - Writing scripts, pauses, pacing
-- **video-generation.md** - Video creation workflow (v2 API)
-- **video-agent.md** - One-shot prompt-to-video generation
-- **prompt-optimizer.md** - Writing effective Video Agent prompts (scene-by-scene structure, timing, visual styles)
-- **dimensions.md** - Resolution and aspect ratios
-
-### Video Customization
-- **backgrounds.md** - Solid colors, images, and video backgrounds
-- **text-overlays.md** - Adding text with fonts and positioning
-- **captions.md** - Auto-generated captions and subtitles
-
-### Advanced Features
-- **templates.md** - Template-based video generation
-- **video-translation.md** - Translation and dubbing
-- **streaming-avatars.md** - Real-time interactive avatars
-- **photo-avatars.md** - Photo-based avatar creation
-- **webhooks.md** - Event notifications
-
-### Integration
-- **remotion-integration.md** - Using HeyGen in Remotion compositions
-
-## Usage
-
-When working with HeyGen code, Claude Code will automatically reference these files to provide accurate, up-to-date guidance.
-
-### Example Prompts
+## Example Prompts
 
 ```
 "Create a 60-second product demo video using the Video Agent API"
 
-"Help me generate a HeyGen video with a custom background"
+"Generate a TTS audio file with an excited female voice"
 
-"How do I list available avatars in HeyGen?"
+"Translate this YouTube video to Spanish and French"
 
-"Create a video translation workflow for Spanish and French"
+"Help me list available HeyGen avatars and pick one for my video"
 
-"Set up webhooks for video completion notifications"
-
-"Use the prompt optimizer to create a scene-by-scene script for my video"
+"Use the prompt optimizer to create a scene-by-scene script"
 ```
-
-### Video Agent Workflow
-
-For quick video generation from a text prompt:
-
-1. Use the **prompt-optimizer.md** guidelines to structure your prompt with scenes, timing, and visual styles
-2. Call the Video Agent API endpoint (`POST /v1/video_agent/generate`)
-3. Poll for status using **video-status.md** patterns
-4. Download the completed video
 
 ## API Reference
 
-The references are based on the HeyGen API documentation:
+All skills use the HeyGen API:
 - Base URL: `https://api.heygen.com`
 - Authentication: `X-Api-Key` header
 - API Versions: v1, v2 (varies by endpoint)
 
 ### Key Endpoints
 
-| Endpoint | Purpose |
-|----------|---------|
-| `POST /v1/video_agent/generate` | One-shot prompt-to-video (Video Agent) |
-| `POST /v2/video/generate` | Precise multi-scene video generation |
-| `GET /v1/video_status.get` | Check video generation status |
-| `GET /v2/avatars` | List available avatars |
-| `GET /v2/voices` | List available voices |
+| Endpoint | Skill | Purpose |
+|----------|-------|---------|
+| `POST /v1/video_agent/generate` | heygen | One-shot prompt-to-video |
+| `POST /v2/video/generate` | heygen | Precise multi-scene video generation |
+| `GET /v1/video_status.get` | heygen | Check video generation status |
+| `GET /v2/avatars` | heygen | List available avatars |
+| `GET /v2/voices` | heygen | List available voices |
+| `POST /v1/audio/text_to_speech` | text-to-speech | Generate speech audio |
+| `GET /v1/audio/voices` | text-to-speech | List TTS-compatible voices |
+| `POST /v2/video_translate` | video-translate | Start video translation |
 
 ## Requirements
 
 - HeyGen API key (get one at [HeyGen Developer Portal](https://app.heygen.com/settings?from=&nav=API))
-- Claude Code CLI
+- Claude Code CLI (or any skills-compatible agent)
 
 ## Contributing
 
-To add or update references:
+To add or update skills:
 
-1. Edit the relevant `.md` file in `skills/heygen/references/`
-2. Update `skills/heygen/SKILL.md` if adding new files
-3. Include both curl and TypeScript/Python examples where applicable
-4. Test that the skill loads correctly
+1. Edit the relevant `SKILL.md` or reference files in `skills/<skill-name>/`
+2. Include curl, TypeScript, and Python examples where applicable
+3. Test that the skill loads correctly
+4. Each skill should be self-contained — no cross-skill dependencies
 
 ## License
 
@@ -179,3 +132,4 @@ MIT
 - [HeyGen API Documentation](https://docs.heygen.com)
 - [HeyGen Developer Portal](https://app.heygen.com/settings?from=&nav=API)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [Agent Skills Specification](https://agentskills.io/specification)

--- a/skills/heygen/SKILL.md
+++ b/skills/heygen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: heygen
 description: |
-  HeyGen AI video creation API. Use when: (1) Using Video Agent for one-shot prompt-to-video generation, (2) Generating AI avatar videos with /v2/video/generate, (3) Working with HeyGen avatars, voices, backgrounds, or captions, (4) Creating transparent WebM videos for compositing, (5) Polling video status or handling webhooks, (6) Integrating HeyGen with Remotion for programmatic video, (7) Translating or dubbing existing videos, (8) Generating standalone TTS audio with the Starfish model via /v1/audio.
+  HeyGen AI video creation API. Use when: (1) Using Video Agent for one-shot prompt-to-video generation, (2) Generating AI avatar videos with /v2/video/generate, (3) Working with HeyGen avatars, voices, backgrounds, or captions, (4) Creating transparent WebM videos for compositing, (5) Polling video status or handling webhooks, (6) Integrating HeyGen with Remotion for programmatic video, (7) Creating photo avatars from images.
 homepage: https://docs.heygen.com/reference/generate-video-agent
 allowed-tools: mcp__heygen__*
 metadata:
@@ -25,8 +25,6 @@ If HeyGen MCP tools are available (`mcp__heygen__*`), **prefer them** over direc
 | Generate video from prompt | `mcp__heygen__generate_video_agent` | `POST /v1/video_agent/generate` |
 | Check video status / get URL | `mcp__heygen__get_video` | `GET /v1/video_status.get` |
 | List account videos | `mcp__heygen__list_videos` | `GET /v1/video.list` |
-| Generate TTS audio | `mcp__heygen__text_to_speech` | `POST /v1/audio/text_to_speech` |
-| List TTS voices | `mcp__heygen__list_audio_voices` | `GET /v1/audio/voices` |
 | Delete a video | `mcp__heygen__delete_video` | `DELETE /v1/video.delete` |
 
 If no HeyGen MCP tools are available, use direct HTTP API calls with `X-Api-Key: $HEYGEN_API_KEY` header as documented in the reference files.
@@ -62,9 +60,6 @@ Only use v2/video/generate when user explicitly needs:
 | Check video status / get download URL | `mcp__heygen__get_video` | [video-status.md](references/video-status.md) |
 | Add captions or text overlays | — | [captions.md](references/captions.md), [text-overlays.md](references/text-overlays.md) |
 | Transparent video for compositing | — | [video-generation.md](references/video-generation.md) (WebM section) |
-| Generate standalone TTS audio | `mcp__heygen__text_to_speech` | [text-to-speech.md](references/text-to-speech.md) |
-| List TTS voices | `mcp__heygen__list_audio_voices` | [voices.md](references/voices.md) |
-| Translate/dub existing video | — | [video-translation.md](references/video-translation.md) |
 | Use with Remotion | — | [remotion-integration.md](references/remotion-integration.md) |
 
 ## Reference Files
@@ -93,8 +88,6 @@ Only use v2/video/generate when user explicitly needs:
 
 ### Advanced Features
 - [references/templates.md](references/templates.md) - Template listing and variable replacement
-- [references/video-translation.md](references/video-translation.md) - Translating videos and dubbing
-- [references/text-to-speech.md](references/text-to-speech.md) - Standalone TTS audio with Starfish model
 - [references/photo-avatars.md](references/photo-avatars.md) - Creating avatars from photos
 - [references/webhooks.md](references/webhooks.md) - Webhook endpoints and events
 

--- a/skills/text-to-speech/SKILL.md
+++ b/skills/text-to-speech/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: text-to-speech
 description: |
-  Generate speech audio from text using HeyGen's Starfish TTS model. Use when: (1) Generating standalone speech audio files from text, (2) Converting text to speech with voice selection, speed, pitch, and emotion control, (3) Creating audio for voiceovers, narration, or podcasts, (4) Working with HeyGen's /v1/audio endpoints, (5) Listing available TTS voices by language or gender.
+  Generate speech audio from text using HeyGen's Starfish TTS model. Use when: (1) Generating standalone speech audio files from text, (2) Converting text to speech with voice selection, speed, and pitch control, (3) Creating audio for voiceovers, narration, or podcasts, (4) Working with HeyGen's /v1/audio endpoints, (5) Listing available TTS voices by language or gender.
 allowed-tools: mcp__heygen__*
 metadata:
   openclaw:
@@ -146,7 +146,6 @@ Convert text to speech audio using a specified voice.
 | `voice_id` | string | Y | Voice ID from `GET /v1/audio/voices` |
 | `speed` | number | | Speech speed, 0.5-1.5 (default: 1) |
 | `pitch` | integer | | Voice pitch, -50 to 50 (default: 0) |
-| `emotion` | string | | Tone: `"Excited"`, `"Friendly"`, `"Serious"`, `"Soothing"`, or `"Broadcaster"` |
 | `locale` | string | | Accent/locale for multilingual voices (e.g., `en-US`, `pt-BR`) |
 | `elevenlabs_settings` | object | | Advanced settings for ElevenLabs voices |
 
@@ -180,7 +179,6 @@ interface TTSRequest {
   voice_id: string;
   speed?: number;
   pitch?: number;
-  emotion?: "Excited" | "Friendly" | "Serious" | "Soothing" | "Broadcaster";
   locale?: string;
   elevenlabs_settings?: {
     model?: string;
@@ -240,7 +238,6 @@ def text_to_speech(
     voice_id: str,
     speed: float = 1.0,
     pitch: int = 0,
-    emotion: str | None = None,
     locale: str | None = None,
 ) -> dict:
     payload = {
@@ -250,8 +247,6 @@ def text_to_speech(
         "pitch": pitch,
     }
 
-    if emotion:
-        payload["emotion"] = emotion
     if locale:
         payload["locale"] = locale
 
@@ -304,14 +299,13 @@ console.log(`Audio URL: ${result.audio_url}`);
 console.log(`Duration: ${result.duration}s`);
 ```
 
-### With Emotion and Speed
+### With Speed Adjustment
 
 ```typescript
 const result = await textToSpeech({
   text: "We're thrilled to announce our newest feature!",
   voice_id: "YOUR_VOICE_ID",
   speed: 1.1,
-  emotion: "Excited",
 });
 ```
 

--- a/skills/text-to-speech/SKILL.md
+++ b/skills/text-to-speech/SKILL.md
@@ -1,27 +1,56 @@
 ---
 name: text-to-speech
-description: Generate speech audio from text using HeyGen's Starfish TTS model
+description: |
+  Generate speech audio from text using HeyGen's Starfish TTS model. Use when: (1) Generating standalone speech audio files from text, (2) Converting text to speech with voice selection, speed, pitch, and emotion control, (3) Creating audio for voiceovers, narration, or podcasts, (4) Working with HeyGen's /v1/audio endpoints, (5) Listing available TTS voices by language or gender.
+allowed-tools: mcp__heygen__*
+metadata:
+  openclaw:
+    requires:
+      env:
+        - HEYGEN_API_KEY
+    primaryEnv: HEYGEN_API_KEY
 ---
 
-# Text-to-Speech (Starfish)
+# Text-to-Speech (HeyGen Starfish)
 
-Generate speech audio files from text using HeyGen's in-house Starfish TTS model. Use this for standalone audio generation — separate from video creation.
+Generate speech audio files from text using HeyGen's in-house Starfish TTS model. This skill is for standalone audio generation — separate from video creation.
 
-## MCP Tools (Preferred)
+## Authentication
 
-If the HeyGen MCP server is connected:
-- **List voices:** `mcp__heygen__list_audio_voices` — filter by type (public/private), language, gender
-- **Generate audio:** `mcp__heygen__text_to_speech` — params: text, voiceId, speed, locale, language
+All requests require the `X-Api-Key` header. Set the `HEYGEN_API_KEY` environment variable.
 
-## List Compatible TTS Voices (Direct API)
+```bash
+curl -X GET "https://api.heygen.com/v1/audio/voices" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+## Tool Selection
+
+If HeyGen MCP tools are available (`mcp__heygen__*`), **prefer them** over direct HTTP API calls.
+
+| Task | MCP Tool | Fallback (Direct API) |
+|------|----------|----------------------|
+| List TTS voices | `mcp__heygen__list_audio_voices` | `GET /v1/audio/voices` |
+| Generate speech audio | `mcp__heygen__text_to_speech` | `POST /v1/audio/text_to_speech` |
+
+## Default Workflow
+
+1. List voices with `mcp__heygen__list_audio_voices` (or `GET /v1/audio/voices`)
+2. Pick a voice matching desired language, gender, and features
+3. Call `mcp__heygen__text_to_speech` (or `POST /v1/audio/text_to_speech`) with text and voice_id
+4. Use the returned `audio_url` to download or play the audio
+
+## List TTS Voices
 
 Retrieve voices compatible with the Starfish TTS model.
+
+> **Note:** This uses `GET /v1/audio/voices` — a different endpoint from the video voices API (`GET /v2/voices`). Not all video voices support Starfish TTS.
 
 ### curl
 
 ```bash
 curl -X GET "https://api.heygen.com/v1/audio/voices" \
-  -H "x-api-key: $HEYGEN_API_KEY"
+  -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
 ### TypeScript
@@ -35,7 +64,7 @@ interface TTSVoice {
   preview_audio_url: string | null;
   support_pause: boolean;
   support_locale: boolean;
-  type: string;                    // e.g., "public"
+  type: string;
 }
 
 interface TTSVoicesResponse {
@@ -47,7 +76,7 @@ interface TTSVoicesResponse {
 
 async function listTTSVoices(): Promise<TTSVoice[]> {
   const response = await fetch("https://api.heygen.com/v1/audio/voices", {
-    headers: { "x-api-key": process.env.HEYGEN_API_KEY! },
+    headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
   });
 
   const json: TTSVoicesResponse = await response.json();
@@ -69,7 +98,7 @@ import os
 def list_tts_voices() -> list:
     response = requests.get(
         "https://api.heygen.com/v1/audio/voices",
-        headers={"x-api-key": os.environ["HEYGEN_API_KEY"]}
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]}
     )
 
     data = response.json()
@@ -101,8 +130,6 @@ def list_tts_voices() -> list:
 }
 ```
 
-> **Note:** This endpoint returns voices compatible with the Starfish TTS model specifically. For voices used in video generation, see [voices.md](voices.md) which uses `GET /v2/voices`.
-
 ## Generate Speech Audio
 
 Convert text to speech audio using a specified voice.
@@ -115,28 +142,28 @@ Convert text to speech audio using a specified voice.
 
 | Field | Type | Req | Description |
 |-------|------|:---:|-------------|
-| `text` | string | ✓ | Text content to convert to speech |
-| `voice_id` | string | ✓ | Voice ID from `GET /v1/audio/voices` |
-| `speed` | number | | Speech speed, 0.5–1.5 (default: 1) |
+| `text` | string | Y | Text content to convert to speech |
+| `voice_id` | string | Y | Voice ID from `GET /v1/audio/voices` |
+| `speed` | number | | Speech speed, 0.5-1.5 (default: 1) |
 | `pitch` | integer | | Voice pitch, -50 to 50 (default: 0) |
 | `emotion` | string | | Tone: `"Excited"`, `"Friendly"`, `"Serious"`, `"Soothing"`, or `"Broadcaster"` |
 | `locale` | string | | Accent/locale for multilingual voices (e.g., `en-US`, `pt-BR`) |
-| `elevenlabs_settings` | object | | Advanced settings for ElevenLabs voices (see below) |
+| `elevenlabs_settings` | object | | Advanced settings for ElevenLabs voices |
 
 ### ElevenLabs Settings (optional)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `model` | string | Model selection (`eleven_v3`, `eleven_turbo_v2_5`, etc.) |
-| `similarity_boost` | number | Voice similarity, 0.0–1.0 |
-| `stability` | number | Output consistency, 0.0–1.0 |
-| `style` | number | Style intensity, 0.0–1.0 |
+| `similarity_boost` | number | Voice similarity, 0.0-1.0 |
+| `stability` | number | Output consistency, 0.0-1.0 |
+| `style` | number | Style intensity, 0.0-1.0 |
 
 ### curl
 
 ```bash
 curl -X POST "https://api.heygen.com/v1/audio/text_to_speech" \
-  -H "x-api-key: $HEYGEN_API_KEY" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "text": "Hello! Welcome to our product demo.",
@@ -151,10 +178,10 @@ curl -X POST "https://api.heygen.com/v1/audio/text_to_speech" \
 interface TTSRequest {
   text: string;
   voice_id: string;
-  speed?: number;                     // 0.5–1.5, default 1
-  pitch?: number;                     // -50 to 50, default 0
+  speed?: number;
+  pitch?: number;
   emotion?: "Excited" | "Friendly" | "Serious" | "Soothing" | "Broadcaster";
-  locale?: string;                    // e.g., "en-US", "pt-BR"
+  locale?: string;
   elevenlabs_settings?: {
     model?: string;
     similarity_boost?: number;
@@ -185,7 +212,7 @@ async function textToSpeech(request: TTSRequest): Promise<TTSResponse["data"]> {
     {
       method: "POST",
       headers: {
-        "x-api-key": process.env.HEYGEN_API_KEY!,
+        "X-Api-Key": process.env.HEYGEN_API_KEY!,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(request),
@@ -231,7 +258,7 @@ def text_to_speech(
     response = requests.post(
         "https://api.heygen.com/v1/audio/text_to_speech",
         headers={
-            "x-api-key": os.environ["HEYGEN_API_KEY"],
+            "X-Api-Key": os.environ["HEYGEN_API_KEY"],
             "Content-Type": "application/json",
         },
         json=payload,
@@ -302,7 +329,6 @@ const result = await textToSpeech({
 
 ```typescript
 async function generateSpeech(text: string, language: string): Promise<string> {
-  // 1. Find a compatible voice
   const voices = await listTTSVoices();
   const voice = voices.find(
     (v) => v.language.toLowerCase().includes(language.toLowerCase())
@@ -312,7 +338,6 @@ async function generateSpeech(text: string, language: string): Promise<string> {
     throw new Error(`No TTS voice found for language: ${language}`);
   }
 
-  // 2. Generate audio
   const result = await textToSpeech({
     text,
     voice_id: voice.voice_id,
@@ -321,48 +346,27 @@ async function generateSpeech(text: string, language: string): Promise<string> {
   return result.audio_url;
 }
 
-// Usage
-const audioUrl = await generateSpeech(
-  "Hello and welcome!",
-  "english"
-);
+const audioUrl = await generateSpeech("Hello and welcome!", "english");
 ```
 
-### Use TTS Audio in Video Generation
+## Pauses with Break Tags
 
-Generate audio first, then use it as a custom audio track in a video:
+Use SSML-style break tags in your text for pauses:
 
-```typescript
-// 1. Generate TTS audio
-const ttsResult = await textToSpeech({
-  text: "This audio was generated with Starfish TTS.",
-  voice_id: "YOUR_VOICE_ID",
-  emotion: "Friendly",
-});
-
-// 2. Use the audio URL in video generation
-const videoConfig = {
-  video_inputs: [
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "audio",
-        audio_url: ttsResult.audio_url, // Use TTS-generated audio
-      },
-    },
-  ],
-};
 ```
+word <break time="1s"/> word
+```
+
+Rules:
+- Use seconds with `s` suffix: `<break time="1.5s"/>`
+- Must have spaces before and after the tag
+- Self-closing tag format
 
 ## Best Practices
 
 1. **Use `GET /v1/audio/voices`** to find compatible voices — not all voices from `GET /v2/voices` support Starfish TTS
 2. **Check `support_locale`** before setting a `locale` — only multilingual voices support locale selection
-3. **Keep speed between 0.8–1.2** for natural-sounding output
+3. **Keep speed between 0.8-1.2** for natural-sounding output
 4. **Preview voices** using the `preview_audio_url` before generating (may be null for some voices)
 5. **Use `word_timestamps`** in the response for caption syncing or timed text overlays
 6. **Use SSML break tags** in your text for pauses: `word <break time="1s"/> word`

--- a/skills/video-translate/SKILL.md
+++ b/skills/video-translate/SKILL.md
@@ -1,11 +1,37 @@
 ---
-name: video-translation
-description: Translating videos, quality/fast modes, and dubbing for HeyGen
+name: video-translate
+description: |
+  Translate and dub existing videos into multiple languages using HeyGen. Use when: (1) Translating a video into another language, (2) Dubbing video content with lip-sync, (3) Creating multi-language versions of existing videos, (4) Audio-only translation without lip-sync, (5) Working with HeyGen's /v2/video_translate endpoint.
+allowed-tools: mcp__heygen__*
+metadata:
+  openclaw:
+    requires:
+      env:
+        - HEYGEN_API_KEY
+    primaryEnv: HEYGEN_API_KEY
 ---
 
-# Video Translation
+# Video Translation (HeyGen)
 
-HeyGen's Video Translation feature allows you to translate and dub existing videos into multiple languages, preserving lip-sync and natural speech patterns.
+Translate and dub existing videos into multiple languages, preserving lip-sync and natural speech patterns. Provide a video URL or HeyGen video ID — no need to create the video on HeyGen first.
+
+## Authentication
+
+All requests require the `X-Api-Key` header. Set the `HEYGEN_API_KEY` environment variable.
+
+```bash
+curl -X POST "https://api.heygen.com/v2/video_translate" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"video_url": "https://example.com/video.mp4", "output_language": "es-ES"}'
+```
+
+## Default Workflow
+
+1. Provide a video URL or HeyGen video ID
+2. Call `POST /v2/video_translate` with the target language
+3. Poll `GET /v2/video_translate/{translate_id}` until status is `completed`
+4. Download the translated video from the returned URL
 
 ## Creating a Translation Job
 
@@ -13,16 +39,16 @@ HeyGen's Video Translation feature allows you to translate and dub existing vide
 
 | Field | Type | Req | Description |
 |-------|------|:---:|-------------|
-| `video_url` | string | ✓* | URL of video to translate (*or `video_id`) |
-| `video_id` | string | ✓* | HeyGen video ID (*or `video_url`) |
-| `output_language` | string | ✓ | Target language code (e.g., "es-ES") |
+| `video_url` | string | Y* | URL of video to translate (*or `video_id`) |
+| `video_id` | string | Y* | HeyGen video ID (*or `video_url`) |
+| `output_language` | string | Y | Target language code (e.g., `"es-ES"`) |
 | `title` | string | | Name for the translated video |
 | `translate_audio_only` | boolean | | Audio only, no lip-sync (faster) |
 | `speaker_num` | number | | Number of speakers in video |
 | `callback_id` | string | | Custom ID for webhook tracking |
 | `callback_url` | string | | URL for completion notification |
 
-**Either** `video_url` **OR** `video_id` must be provided.
+**Either** `video_url` **or** `video_id` must be provided.
 
 ### curl
 
@@ -41,9 +67,9 @@ curl -X POST "https://api.heygen.com/v2/video_translate" \
 
 ```typescript
 interface VideoTranslateRequest {
-  video_url?: string;                          // Required (or video_id)
-  video_id?: string;                           // Required (or video_url)
-  output_language: string;                     // Required
+  video_url?: string;
+  video_id?: string;
+  output_language: string;
   title?: string;
   translate_audio_only?: boolean;
   speaker_num?: number;
@@ -120,24 +146,20 @@ def translate_video(config: dict) -> str:
 
 ## Translation Options
 
-### Basic Translation
-
-Translate video with lip-sync:
+### Basic Translation (with lip-sync)
 
 ```typescript
-const translateConfig = {
+const config = {
   video_url: "https://example.com/original.mp4",
   output_language: "es-ES",
   title: "Spanish Translation",
 };
 ```
 
-### Audio-Only Translation
-
-Keep original video, only translate audio:
+### Audio-Only Translation (faster, no lip-sync)
 
 ```typescript
-const audioOnlyConfig = {
+const config = {
   video_url: "https://example.com/original.mp4",
   output_language: "es-ES",
   translate_audio_only: true,
@@ -146,13 +168,11 @@ const audioOnlyConfig = {
 
 ### Multi-Speaker Videos
 
-Specify number of speakers for better detection:
-
 ```typescript
-const multiSpeakerConfig = {
+const config = {
   video_url: "https://example.com/interview.mp4",
   output_language: "fr-FR",
-  speaker_num: 2, // Two speakers in video
+  speaker_num: 2,
 };
 ```
 
@@ -164,14 +184,13 @@ For more control over translation:
 interface VideoTranslateV4Request {
   input_video_id?: string;
   google_url?: string;
-  output_languages: string[];
+  output_languages: string[];        // Multiple languages in one call
   name: string;
-  srt_key?: string;
+  srt_key?: string;                  // Custom SRT subtitles
   instruction?: string;
-  vocabulary?: string[];
+  vocabulary?: string[];             // Terms to preserve as-is
   brand_voice_id?: string;
   speaker_num?: number;
-  project_id?: string;
   keep_the_same_format?: boolean;
   input_language?: string;
   enable_video_stretching?: boolean;
@@ -185,36 +204,31 @@ interface VideoTranslateV4Request {
 ### Multiple Output Languages
 
 ```typescript
-const multiLanguageConfig = {
+const config = {
   input_video_id: "original_video_id",
   output_languages: ["es-ES", "fr-FR", "de-DE"],
   name: "Multi-language translations",
 };
 ```
 
-### Custom Vocabulary
-
-Preserve specific terms:
+### Custom Vocabulary (preserve specific terms)
 
 ```typescript
-const customVocabConfig = {
+const config = {
   video_url: "https://example.com/product-demo.mp4",
   output_language: "ja-JP",
   vocabulary: ["SuperWidget", "Pro Max", "TechCorp"],
-  // These terms will be kept as-is or transliterated appropriately
 };
 ```
 
-### Using Custom SRT
-
-Provide your own subtitles:
+### Custom SRT Subtitles
 
 ```typescript
-const customSrtConfig = {
+const config = {
   video_url: "https://example.com/video.mp4",
   output_language: "es-ES",
   srt_key: "path/to/custom-subtitles.srt",
-  srt_role: "input", // Use SRT as source transcript
+  srt_role: "input",
 };
 ```
 
@@ -258,11 +272,13 @@ async function getTranslateStatus(translateId: string): Promise<TranslateStatusR
 
 ## Polling for Completion
 
+Translations take longer than standard video generation — allow up to 30 minutes.
+
 ```typescript
 async function waitForTranslation(
   translateId: string,
-  maxWaitMs = 1800000, // 30 minutes (translations can take longer)
-  pollIntervalMs = 30000 // 30 seconds
+  maxWaitMs = 1800000,
+  pollIntervalMs = 30000
 ): Promise<string> {
   const startTime = Date.now();
 
@@ -284,14 +300,13 @@ async function waitForTranslation(
 }
 ```
 
-## Complete Translation Workflow
+## Complete Workflow
 
 ```typescript
 async function translateAndDownload(
   videoUrl: string,
   targetLanguage: string
 ): Promise<string> {
-  // 1. Start translation
   console.log(`Starting translation to ${targetLanguage}...`);
   const translateId = await translateVideo({
     video_url: videoUrl,
@@ -299,7 +314,6 @@ async function translateAndDownload(
   });
   console.log(`Translation ID: ${translateId}`);
 
-  // 2. Wait for completion
   console.log("Processing translation...");
   const translatedVideoUrl = await waitForTranslation(translateId);
   console.log(`Translation complete: ${translatedVideoUrl}`);
@@ -307,7 +321,6 @@ async function translateAndDownload(
   return translatedVideoUrl;
 }
 
-// Usage
 const spanishVideo = await translateAndDownload(
   "https://example.com/my-video.mp4",
   "es-ES"
@@ -316,7 +329,7 @@ const spanishVideo = await translateAndDownload(
 
 ## Batch Translation
 
-Translate to multiple languages:
+Translate to multiple languages in parallel:
 
 ```typescript
 async function translateToMultipleLanguages(
@@ -325,7 +338,6 @@ async function translateToMultipleLanguages(
 ): Promise<Record<string, string>> {
   const results: Record<string, string> = {};
 
-  // Start all translations in parallel
   const translatePromises = targetLanguages.map(async (lang) => {
     const translateId = await translateVideo({
       video_url: sourceVideoUrl,
@@ -336,14 +348,11 @@ async function translateToMultipleLanguages(
 
   const translationJobs = await Promise.all(translatePromises);
 
-  // Wait for all to complete
   for (const job of translationJobs) {
     try {
       const videoUrl = await waitForTranslation(job.translateId);
       results[job.lang] = videoUrl;
-      console.log(`✓ ${job.lang} complete`);
     } catch (error) {
-      console.error(`✗ ${job.lang} failed: ${error.message}`);
       results[job.lang] = `error: ${error.message}`;
     }
   }
@@ -351,61 +360,31 @@ async function translateToMultipleLanguages(
   return results;
 }
 
-// Usage
 const translations = await translateToMultipleLanguages(
   "https://example.com/original.mp4",
   ["es-ES", "fr-FR", "de-DE", "ja-JP"]
 );
 ```
 
-## Video Translation Features
+## Features
 
-### Lip Sync
-
-HeyGen automatically adjusts the speaker's lip movements to match the translated audio, creating a natural-looking result.
-
-### Voice Cloning
-
-The translated audio attempts to match the original speaker's voice characteristics while speaking the target language.
-
-### Music Track Handling
-
-```typescript
-const config = {
-  video_url: "https://example.com/video-with-music.mp4",
-  output_language: "fr-FR",
-  disable_music_track: true, // Remove background music
-};
-```
-
-### Speech Enhancement
-
-```typescript
-const config = {
-  video_url: "https://example.com/video.mp4",
-  output_language: "de-DE",
-  enable_speech_enhancement: true, // Improve audio quality
-};
-```
+- **Lip Sync** — Automatically adjusts speaker's lip movements to match translated audio
+- **Voice Cloning** — Translated audio matches the original speaker's voice characteristics
+- **Music Track Control** — Optionally remove background music with `disable_music_track: true`
+- **Speech Enhancement** — Improve audio quality with `enable_speech_enhancement: true`
 
 ## Best Practices
 
-1. **Source quality matters** - Use high-quality source videos for better results
-2. **Clear audio** - Videos with clear speech translate better
-3. **Single speaker** - Best results with single-speaker content
-4. **Moderate pacing** - Very fast speech may affect quality
-5. **Test first** - Try with shorter clips before translating long videos
-6. **Allow extra time** - Translation takes longer than generation
-
-## Limitations
-
-- Maximum video duration varies by subscription tier
-- Some complex audio scenarios may reduce quality
-- Background noise can affect translation accuracy
-- Processing time is longer than standard video generation
-- Multi-speaker detection has limitations
+1. **Source quality matters** — Use high-quality source videos for better results
+2. **Clear audio** — Videos with clear speech translate better
+3. **Single speaker** — Best results with single-speaker content
+4. **Moderate pacing** — Very fast speech may affect quality
+5. **Test first** — Try with shorter clips before translating long videos
+6. **Allow extra time** — Translation takes longer than video generation (up to 30 min)
 
 ## Error Handling
+
+Common errors and how to handle them:
 
 ```typescript
 async function safeTranslate(
@@ -416,9 +395,6 @@ async function safeTranslate(
     const url = await translateAndDownload(videoUrl, targetLanguage);
     return { success: true, result: url };
   } catch (error) {
-    console.error(`Translation failed: ${error.message}`);
-
-    // Common error handling
     if (error.message.includes("quota")) {
       return { success: false, error: "Insufficient credits" };
     }
@@ -428,7 +404,6 @@ async function safeTranslate(
     if (error.message.includes("format")) {
       return { success: false, error: "Unsupported video format" };
     }
-
     return { success: false, error: error.message };
   }
 }


### PR DESCRIPTION
## Summary

- Reorganizes from a single monolithic `heygen` skill into three focused, self-contained skills following the Anthropic multi-skill pattern (e.g., [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills))
- **`heygen`** — Video creation (Video Agent + v2 API, avatars, voices, prompts, Remotion)
- **`text-to-speech`** — Standalone TTS audio via `/v1/audio` endpoints (different output type, different API surface)
- **`video-translate`** — Video translation & dubbing via `/v2/video_translate` (users bring their own video)
- Each skill is fully self-contained with inline auth — no cross-skill dependencies
- Adds `.claude-plugin/` manifests for Claude Code plugin marketplace distribution
- Adds `CLAUDE.md` with project conventions and skill authoring guide
- Updates CI workflow to publish all 3 skills to ClawHub
- Rewrites README with skills table and multi-install options

## Distribution channels (all work simultaneously)

| Channel | Command |
|---------|---------|
| Claude Code plugins | `/plugin marketplace add heygen-com/skills` |
| Vercel skills.sh | `npx skills add heygen-com/skills` |
| ClawHub | Auto-publishes on merge (3 separate listings) |

## Test plan

- [ ] Symlink all 3 skills to `~/.claude/skills/` and start a fresh Claude Code session
- [ ] Verify `/heygen` triggers on "Create a 30 second product demo video"
- [ ] Verify `/text-to-speech` triggers on "Generate a TTS audio file saying hello"
- [ ] Verify `/video-translate` triggers on "Translate this video to Spanish"
- [ ] Verify skills are isolated (TTS should not load avatars.md or video-generation.md)
- [ ] Run `npx skills add . --list` locally to confirm all 3 skills are discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)