### PR TITLE
update clawhub skills to remove sus commands

### DIFF
--- a/skills/heygen/references/assets.md
+++ b/skills/heygen/references/assets.md
@@ -51,6 +51,7 @@ curl -X POST "https://upload.heygen.com/v1/asset" \
 
 ```typescript
 import fs from "fs";
+import path from "path";
 
 interface AssetUploadResponse {
   code: number;
@@ -69,7 +70,8 @@ interface AssetUploadResponse {
 }
 
 async function uploadAsset(filePath: string, contentType: string): Promise<AssetUploadResponse["data"]> {
-  const fileBuffer = fs.readFileSync(filePath);
+  const resolvedPath = path.resolve(filePath);
+  const fileBuffer = fs.readFileSync(resolvedPath);
 
   const response = await fetch("https://upload.heygen.com/v1/asset", {
     method: "POST",
@@ -99,11 +101,13 @@ console.log(`Asset URL: ${asset.url}`);
 
 ```typescript
 import fs from "fs";
+import path from "path";
 import { stat } from "fs/promises";
 
 async function uploadLargeAsset(filePath: string, contentType: string): Promise<AssetUploadResponse["data"]> {
-  const fileStats = await stat(filePath);
-  const fileStream = fs.createReadStream(filePath);
+  const resolvedPath = path.resolve(filePath);
+  const fileStats = await stat(resolvedPath);
+  const fileStream = fs.createReadStream(resolvedPath);
 
   const response = await fetch("https://upload.heygen.com/v1/asset", {
     method: "POST",
@@ -174,7 +178,11 @@ If your asset is already hosted online:
 
 ```typescript
 async function uploadFromUrl(sourceUrl: string, contentType: string): Promise<AssetUploadResponse["data"]> {
-  // 1. Download the file
+  // 1. Validate and download the file
+  const url = new URL(sourceUrl);
+  if (url.protocol !== "https:") {
+    throw new Error("Only HTTPS URLs are supported");
+  }
   const sourceResponse = await fetch(sourceUrl);
   const buffer = Buffer.from(await sourceResponse.arrayBuffer());
 

--- a/skills/heygen/references/avatars.md
+++ b/skills/heygen/references/avatars.md
@@ -46,18 +46,12 @@ async function listAndPreviewAvatars(openInBrowser = true): Promise<void> {
     console.log(`  Preview: ${avatar.preview_image_url}`);
   }
 
-  // Open preview URLs directly in browser (no download needed)
-  if (openInBrowser) {
-    const { execSync } = require("child_process");
-    for (const avatar of data.avatars.slice(0, 3)) {
-      // 'open' on macOS opens the URL in default browser - doesn't download
-      execSync(`open "${avatar.preview_image_url}"`);
-    }
+  // Preview URLs can be opened directly in any browser
+  for (const avatar of data.avatars.slice(0, 3)) {
+    console.log(`Open in browser: ${avatar.preview_image_url}`);
   }
 }
 ```
-
-**Note:** The `open` command passes the URL to the browser - it does not download. The browser fetches and displays the image directly.
 
 ### Workflow: Preview Before Generate
 

--- a/skills/heygen/references/photo-avatars.md
+++ b/skills/heygen/references/photo-avatars.md
@@ -121,6 +121,7 @@ const videoConfig = {
 
 ```typescript
 import fs from "fs";
+import path from "path";
 
 interface AssetUploadResponse {
   code: number;
@@ -149,7 +150,8 @@ async function createPhotoAvatar(
   name: string
 ): Promise<string> {
   // 1. Upload image
-  const fileBuffer = fs.readFileSync(imagePath);
+  const resolvedPath = path.resolve(imagePath);
+  const fileBuffer = fs.readFileSync(resolvedPath);
   const uploadResponse = await fetch("https://upload.heygen.com/v1/asset", {
     method: "POST",
     headers: {

--- a/skills/heygen/references/video-status.md
+++ b/skills/heygen/references/video-status.md
@@ -246,10 +246,11 @@ Once the video is complete, download it. **Important**: The video URL may not be
 
 ```typescript
 import fs from "fs";
+import path from "path";
 
 async function downloadVideoWithRetry(
   videoUrl: string,
-  outputPath: string,
+  outputPath = "./output/video.mp4",
   maxRetries = 5,
   initialDelayMs = 2000
 ): Promise<void> {
@@ -264,7 +265,7 @@ async function downloadVideoWithRetry(
       }
 
       const arrayBuffer = await response.arrayBuffer();
-      fs.writeFileSync(outputPath, Buffer.from(arrayBuffer));
+      fs.writeFileSync(path.resolve(outputPath), Buffer.from(arrayBuffer));
       console.log(`Video downloaded to ${outputPath}`);
       return;
     } catch (error) {
@@ -318,13 +319,13 @@ def download_video_with_retry(
 For quick scripts where you'll retry manually:
 
 ```typescript
-async function downloadVideo(videoUrl: string, outputPath: string) {
+async function downloadVideo(videoUrl: string, outputPath = "./output/video.mp4") {
   const response = await fetch(videoUrl);
   if (!response.ok) {
     throw new Error(`Failed to download: ${response.status}`);
   }
   const arrayBuffer = await response.arrayBuffer();
-  fs.writeFileSync(outputPath, Buffer.from(arrayBuffer));
+  fs.writeFileSync(path.resolve(outputPath), Buffer.from(arrayBuffer));
 }
 ```
 


### PR DESCRIPTION
### TL;DR

Enhanced file path handling and URL validation in HeyGen API documentation examples

### What changed?

- Added `path.resolve()` calls to all file operations to ensure absolute paths are used consistently
- Imported the `path` module in TypeScript examples where file operations occur
- Added HTTPS URL validation in the `uploadFromUrl` function to reject non-secure URLs
- Removed browser automation code from avatar preview examples, replacing with simple console output
- Added default parameter values for output paths in video download functions

### How to test?

1. Test file upload examples with relative paths (e.g., `./image.jpg`) to verify they resolve correctly
2. Try the `uploadFromUrl` function with HTTP URLs to confirm the validation error is thrown
3. Run the avatar listing function to verify it outputs preview URLs without attempting browser automation
4. Test video download functions without specifying output paths to confirm default values work

### Why make this change?

These changes improve the robustness and portability of the code examples. Using `path.resolve()` prevents issues with relative paths in different execution contexts, HTTPS validation ensures secure file transfers, removing browser automation makes the examples more universally compatible across different environments, and default parameters reduce the likelihood of errors when users don't specify all arguments.