### PR TITLE
update github action for tts

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Publish text-to-speech skill
         run: |
           clawhub publish ./skills/text-to-speech \
-            --slug text-to-speech \
+            --slug text-to-speech-heygen \
             --name "Text to Speech" \
             --version 2.${{ github.run_number }}.0 \
             --tags latest,tts,text-to-speech,heygen,audio,voice,speech,starfish \


### PR DESCRIPTION
### TL;DR

Updated the slug for the text-to-speech skill publication from `text-to-speech` to `text-to-speech-heygen`.

### What changed?

Modified the `--slug` parameter in the GitHub workflow for publishing the text-to-speech skill to use `text-to-speech-heygen` instead of `text-to-speech`.

### How to test?

Trigger the publish workflow and verify that the skill is published with the new slug `text-to-speech-heygen` on the clawhub platform.

### Why make this change?

This change likely provides better specificity by indicating that this text-to-speech implementation uses HeyGen, helping to distinguish it from other text-to-speech skills and making it more discoverable for users specifically looking for HeyGen-based solutions.