### PR TITLE
Add generate-video skill for AI video generation via Node Gateway

### DIFF
--- a/skills/ai-video-gen/SKILL.md
+++ b/skills/ai-video-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: generate-video
+name: ai-video-gen
 description: |
-  Generate AI videos from text prompts using the HeyGen API. Use when: (1) Generating videos from text descriptions, (2) Creating AI-generated video clips for content production, (3) Image-to-video generation with a reference image, (4) Choosing between video generation providers (VEO, Kling, Sora, Runway, Seedance), (5) Working with HeyGen's /v1/nodes/executions endpoint for video generation.
+  Generate AI videos from text prompts using the HeyGen API. Use when: (1) Generating videos from text descriptions, (2) Creating AI-generated video clips for content production, (3) Image-to-video generation with a reference image, (4) Choosing between video generation providers (VEO, Kling, Sora, Runway, Seedance), (5) Working with HeyGen's /v1/workflows/executions endpoint for video generation.
 allowed-tools: mcp__heygen__*
 metadata:
   openclaw:
@@ -20,30 +20,30 @@ Generate AI videos from text prompts. Supports multiple providers (VEO 3.1, Klin
 All requests require the `X-Api-Key` header. Set the `HEYGEN_API_KEY` environment variable.
 
 ```bash
-curl -X POST "https://api.heygen.com/v1/nodes/executions" \
+curl -X POST "https://api.heygen.com/v1/workflows/executions" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"node_type": "GenerateVideoNode", "input": {"prompt": "A drone shot flying over a coastal city at sunset"}}'
+  -d '{"workflow_type": "GenerateVideoNode", "input": {"prompt": "A drone shot flying over a coastal city at sunset"}}'
 ```
 
 ## Default Workflow
 
-1. Call `POST /v1/nodes/executions` with `node_type: "GenerateVideoNode"` and your prompt
+1. Call `POST /v1/workflows/executions` with `workflow_type: "GenerateVideoNode"` and your prompt
 2. Receive a `execution_id` in the response
-3. Poll `GET /v1/nodes/executions/{id}` every 10 seconds until status is `completed`
+3. Poll `GET /v1/workflows/executions/{id}` every 10 seconds until status is `completed`
 4. Use the returned `video_url` from the output
 
 ## Execute Video Generation
 
 ### Endpoint
 
-`POST https://api.heygen.com/v1/nodes/executions`
+`POST https://api.heygen.com/v1/workflows/executions`
 
 ### Request Fields
 
 | Field | Type | Req | Description |
 |-------|------|:---:|-------------|
-| `node_type` | string | Y | Must be `"GenerateVideoNode"` |
+| `workflow_type` | string | Y | Must be `"GenerateVideoNode"` |
 | `input.prompt` | string | Y | Text description of the video to generate |
 | `input.provider` | string | | Video generation provider (default: `"veo_3_1"`). See Providers below. |
 | `input.aspect_ratio` | string | | Aspect ratio (default: `"16:9"`). Common values: `"16:9"`, `"9:16"`, `"1:1"` |
@@ -72,11 +72,11 @@ curl -X POST "https://api.heygen.com/v1/nodes/executions" \
 ### curl
 
 ```bash
-curl -X POST "https://api.heygen.com/v1/nodes/executions" \
+curl -X POST "https://api.heygen.com/v1/workflows/executions" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "node_type": "GenerateVideoNode",
+    "workflow_type": "GenerateVideoNode",
     "input": {
       "prompt": "A drone shot flying over a coastal city at golden hour, cinematic lighting",
       "provider": "veo_3_1",
@@ -105,14 +105,14 @@ interface ExecuteResponse {
 }
 
 async function generateVideo(input: GenerateVideoInput): Promise<string> {
-  const response = await fetch("https://api.heygen.com/v1/nodes/executions", {
+  const response = await fetch("https://api.heygen.com/v1/workflows/executions", {
     method: "POST",
     headers: {
       "X-Api-Key": process.env.HEYGEN_API_KEY!,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      node_type: "GenerateVideoNode",
+      workflow_type: "GenerateVideoNode",
       input,
     }),
   });
@@ -136,7 +136,7 @@ def generate_video(
     tail_image_url: str | None = None,
 ) -> str:
     payload = {
-        "node_type": "GenerateVideoNode",
+        "workflow_type": "GenerateVideoNode",
         "input": {
             "prompt": prompt,
             "provider": provider,
@@ -150,7 +150,7 @@ def generate_video(
         payload["input"]["tail_image_url"] = tail_image_url
 
     response = requests.post(
-        "https://api.heygen.com/v1/nodes/executions",
+        "https://api.heygen.com/v1/workflows/executions",
         headers={
             "X-Api-Key": os.environ["HEYGEN_API_KEY"],
             "Content-Type": "application/json",
@@ -177,12 +177,12 @@ def generate_video(
 
 ### Endpoint
 
-`GET https://api.heygen.com/v1/nodes/executions/{execution_id}`
+`GET https://api.heygen.com/v1/workflows/executions/{execution_id}`
 
 ### curl
 
 ```bash
-curl -X GET "https://api.heygen.com/v1/nodes/executions/node-gw-v1d2e3o4" \
+curl -X GET "https://api.heygen.com/v1/workflows/executions/node-gw-v1d2e3o4" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
@@ -218,7 +218,7 @@ async function generateVideoAndWait(
   const startTime = Date.now();
   while (Date.now() - startTime < maxWaitMs) {
     const response = await fetch(
-      `https://api.heygen.com/v1/nodes/executions/${executionId}`,
+      `https://api.heygen.com/v1/workflows/executions/${executionId}`,
       { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
     );
     const { data } = await response.json();
@@ -248,11 +248,11 @@ async function generateVideoAndWait(
 ### Simple Text-to-Video
 
 ```bash
-curl -X POST "https://api.heygen.com/v1/nodes/executions" \
+curl -X POST "https://api.heygen.com/v1/workflows/executions" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "node_type": "GenerateVideoNode",
+    "workflow_type": "GenerateVideoNode",
     "input": {
       "prompt": "A person walking through a sunlit park, shallow depth of field"
     }
@@ -263,7 +263,7 @@ curl -X POST "https://api.heygen.com/v1/nodes/executions" \
 
 ```json
 {
-  "node_type": "GenerateVideoNode",
+  "workflow_type": "GenerateVideoNode",
   "input": {
     "prompt": "Animate this product photo with a slow zoom and soft particle effects",
     "reference_image_url": "https://example.com/product-photo.png",
@@ -276,7 +276,7 @@ curl -X POST "https://api.heygen.com/v1/nodes/executions" \
 
 ```json
 {
-  "node_type": "GenerateVideoNode",
+  "workflow_type": "GenerateVideoNode",
   "input": {
     "prompt": "A trendy coffee shop interior, camera slowly panning across the counter",
     "aspect_ratio": "9:16",
@@ -289,7 +289,7 @@ curl -X POST "https://api.heygen.com/v1/nodes/executions" \
 
 ```json
 {
-  "node_type": "GenerateVideoNode",
+  "workflow_type": "GenerateVideoNode",
   "input": {
     "prompt": "Abstract colorful shapes morphing and flowing",
     "provider": "ltx_distilled"
@@ -302,7 +302,7 @@ curl -X POST "https://api.heygen.com/v1/nodes/executions" \
 1. **Be descriptive in prompts** — include camera movement, lighting, style, and mood details
 2. **Default to VEO 3.1** for highest quality; use `ltx_distilled` or `veo3_fast` when speed matters
 3. **Use reference images** for image-to-video generation — great for animating product photos or still images
-4. **Video generation is the slowest node** — allow up to 5 minutes, poll every 10 seconds
+4. **Video generation is the slowest workflow** — allow up to 5 minutes, poll every 10 seconds
 5. **Aspect ratio matters** — use `9:16` for social media stories/reels, `16:9` for landscape, `1:1` for square
 6. **Output includes `asset_id`** — use this to reference the generated video in other HeyGen workflows
 7. **Output URLs are temporary** — download or save generated videos promptly

--- a/skills/generate-video/SKILL.md
+++ b/skills/generate-video/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: generate-video
+description: |
+  Generate AI videos from text prompts using the HeyGen API. Use when: (1) Generating videos from text descriptions, (2) Creating AI-generated video clips for content production, (3) Image-to-video generation with a reference image, (4) Choosing between video generation providers (VEO, Kling, Sora, Runway, Seedance), (5) Working with HeyGen's /v1/nodes/executions endpoint for video generation.
+allowed-tools: mcp__heygen__*
+metadata:
+  openclaw:
+    requires:
+      env:
+        - HEYGEN_API_KEY
+    primaryEnv: HEYGEN_API_KEY
+---
+
+# Video Generation (HeyGen API)
+
+Generate AI videos from text prompts. Supports multiple providers (VEO 3.1, Kling, Sora, Runway, Seedance), configurable aspect ratios, and optional reference images for image-to-video generation.
+
+## Authentication
+
+All requests require the `X-Api-Key` header. Set the `HEYGEN_API_KEY` environment variable.
+
+```bash
+curl -X POST "https://api.heygen.com/v1/nodes/executions" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"node_type": "GenerateVideoNode", "input": {"prompt": "A drone shot flying over a coastal city at sunset"}}'
+```
+
+## Default Workflow
+
+1. Call `POST /v1/nodes/executions` with `node_type: "GenerateVideoNode"` and your prompt
+2. Receive a `execution_id` in the response
+3. Poll `GET /v1/nodes/executions/{id}` every 10 seconds until status is `completed`
+4. Use the returned `video_url` from the output
+
+## Execute Video Generation
+
+### Endpoint
+
+`POST https://api.heygen.com/v1/nodes/executions`
+
+### Request Fields
+
+| Field | Type | Req | Description |
+|-------|------|:---:|-------------|
+| `node_type` | string | Y | Must be `"GenerateVideoNode"` |
+| `input.prompt` | string | Y | Text description of the video to generate |
+| `input.provider` | string | | Video generation provider (default: `"veo_3_1"`). See Providers below. |
+| `input.aspect_ratio` | string | | Aspect ratio (default: `"16:9"`). Common values: `"16:9"`, `"9:16"`, `"1:1"` |
+| `input.reference_image_url` | string | | Reference image URL for image-to-video generation |
+| `input.tail_image_url` | string | | Tail image URL for last-frame guidance |
+| `input.config` | object | | Provider-specific configuration overrides |
+
+### Providers
+
+| Provider | Value | Description |
+|----------|-------|-------------|
+| VEO 3.1 | `"veo_3_1"` | Google VEO 3.1 (default, highest quality) |
+| VEO 3.1 Fast | `"veo_3_1_fast"` | Faster VEO 3.1 variant |
+| VEO 3 | `"veo3"` | Google VEO 3 |
+| VEO 3 Fast | `"veo3_fast"` | Faster VEO 3 variant |
+| VEO 2 | `"veo2"` | Google VEO 2 |
+| Kling Pro | `"kling_pro"` | Kling Pro model |
+| Kling V2 | `"kling_v2"` | Kling V2 model |
+| Sora V2 | `"sora_v2"` | OpenAI Sora V2 |
+| Sora V2 Pro | `"sora_v2_pro"` | OpenAI Sora V2 Pro |
+| Runway Gen-4 | `"runway_gen4"` | Runway Gen-4 |
+| Seedance Lite | `"seedance_lite"` | Seedance Lite |
+| Seedance Pro | `"seedance_pro"` | Seedance Pro |
+| LTX Distilled | `"ltx_distilled"` | LTX Distilled (fastest) |
+
+### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v1/nodes/executions" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "node_type": "GenerateVideoNode",
+    "input": {
+      "prompt": "A drone shot flying over a coastal city at golden hour, cinematic lighting",
+      "provider": "veo_3_1",
+      "aspect_ratio": "16:9"
+    }
+  }'
+```
+
+### TypeScript
+
+```typescript
+interface GenerateVideoInput {
+  prompt: string;
+  provider?: string;
+  aspect_ratio?: string;
+  reference_image_url?: string;
+  tail_image_url?: string;
+  config?: Record<string, any>;
+}
+
+interface ExecuteResponse {
+  data: {
+    execution_id: string;
+    status: "submitted";
+  };
+}
+
+async function generateVideo(input: GenerateVideoInput): Promise<string> {
+  const response = await fetch("https://api.heygen.com/v1/nodes/executions", {
+    method: "POST",
+    headers: {
+      "X-Api-Key": process.env.HEYGEN_API_KEY!,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      node_type: "GenerateVideoNode",
+      input,
+    }),
+  });
+
+  const json: ExecuteResponse = await response.json();
+  return json.data.execution_id;
+}
+```
+
+### Python
+
+```python
+import requests
+import os
+
+def generate_video(
+    prompt: str,
+    provider: str = "veo_3_1",
+    aspect_ratio: str = "16:9",
+    reference_image_url: str | None = None,
+    tail_image_url: str | None = None,
+) -> str:
+    payload = {
+        "node_type": "GenerateVideoNode",
+        "input": {
+            "prompt": prompt,
+            "provider": provider,
+            "aspect_ratio": aspect_ratio,
+        },
+    }
+
+    if reference_image_url:
+        payload["input"]["reference_image_url"] = reference_image_url
+    if tail_image_url:
+        payload["input"]["tail_image_url"] = tail_image_url
+
+    response = requests.post(
+        "https://api.heygen.com/v1/nodes/executions",
+        headers={
+            "X-Api-Key": os.environ["HEYGEN_API_KEY"],
+            "Content-Type": "application/json",
+        },
+        json=payload,
+    )
+
+    data = response.json()
+    return data["data"]["execution_id"]
+```
+
+### Response Format
+
+```json
+{
+  "data": {
+    "execution_id": "node-gw-v1d2e3o4",
+    "status": "submitted"
+  }
+}
+```
+
+## Check Status
+
+### Endpoint
+
+`GET https://api.heygen.com/v1/nodes/executions/{execution_id}`
+
+### curl
+
+```bash
+curl -X GET "https://api.heygen.com/v1/nodes/executions/node-gw-v1d2e3o4" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+### Response Format (Completed)
+
+```json
+{
+  "data": {
+    "execution_id": "node-gw-v1d2e3o4",
+    "status": "completed",
+    "output": {
+      "video": {
+        "video_url": "https://resource.heygen.ai/generated/video.mp4",
+        "video_id": "abc123"
+      },
+      "asset_id": "asset-xyz789"
+    }
+  }
+}
+```
+
+## Polling for Completion
+
+```typescript
+async function generateVideoAndWait(
+  input: GenerateVideoInput,
+  maxWaitMs = 600000,
+  pollIntervalMs = 10000
+): Promise<{ video_url: string; video_id: string; asset_id: string }> {
+  const executionId = await generateVideo(input);
+  console.log(`Submitted video generation: ${executionId}`);
+
+  const startTime = Date.now();
+  while (Date.now() - startTime < maxWaitMs) {
+    const response = await fetch(
+      `https://api.heygen.com/v1/nodes/executions/${executionId}`,
+      { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
+    );
+    const { data } = await response.json();
+
+    switch (data.status) {
+      case "completed":
+        return {
+          video_url: data.output.video.video_url,
+          video_id: data.output.video.video_id,
+          asset_id: data.output.asset_id,
+        };
+      case "failed":
+        throw new Error(data.error?.message || "Video generation failed");
+      case "not_found":
+        throw new Error("Workflow not found");
+      default:
+        await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
+  }
+
+  throw new Error("Video generation timed out");
+}
+```
+
+## Usage Examples
+
+### Simple Text-to-Video
+
+```bash
+curl -X POST "https://api.heygen.com/v1/nodes/executions" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "node_type": "GenerateVideoNode",
+    "input": {
+      "prompt": "A person walking through a sunlit park, shallow depth of field"
+    }
+  }'
+```
+
+### Image-to-Video
+
+```json
+{
+  "node_type": "GenerateVideoNode",
+  "input": {
+    "prompt": "Animate this product photo with a slow zoom and soft particle effects",
+    "reference_image_url": "https://example.com/product-photo.png",
+    "provider": "kling_pro"
+  }
+}
+```
+
+### Vertical Format for Social Media
+
+```json
+{
+  "node_type": "GenerateVideoNode",
+  "input": {
+    "prompt": "A trendy coffee shop interior, camera slowly panning across the counter",
+    "aspect_ratio": "9:16",
+    "provider": "veo_3_1"
+  }
+}
+```
+
+### Fast Generation with LTX
+
+```json
+{
+  "node_type": "GenerateVideoNode",
+  "input": {
+    "prompt": "Abstract colorful shapes morphing and flowing",
+    "provider": "ltx_distilled"
+  }
+}
+```
+
+## Best Practices
+
+1. **Be descriptive in prompts** — include camera movement, lighting, style, and mood details
+2. **Default to VEO 3.1** for highest quality; use `ltx_distilled` or `veo3_fast` when speed matters
+3. **Use reference images** for image-to-video generation — great for animating product photos or still images
+4. **Video generation is the slowest node** — allow up to 5 minutes, poll every 10 seconds
+5. **Aspect ratio matters** — use `9:16` for social media stories/reels, `16:9` for landscape, `1:1` for square
+6. **Output includes `asset_id`** — use this to reference the generated video in other HeyGen workflows
+7. **Output URLs are temporary** — download or save generated videos promptly


### PR DESCRIPTION
## Add HeyGen video generation skill

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

This adds a new skill for generating AI videos from text prompts using the HeyGen API. The skill supports:

- Multiple video generation providers (VEO 3.1, Kling, Sora, Runway, Seedance, LTX)
- Configurable aspect ratios (16:9, 9:16, 1:1)
- Image-to-video generation with reference images
- Text-to-video generation with detailed prompts
- Polling workflow for checking generation status

The skill includes comprehensive documentation with curl examples, TypeScript/Python code samples, and best practices for prompt engineering and provider selection. It requires the `HEYGEN_API_KEY` environment variable and uses the HeyGen `/v1/nodes/executions` endpoint.