### PR TITLE
Migrate v1 video endpoints to v2/videos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,5 +117,5 @@ Three channels, one repo:
 - Base URL: `https://api.heygen.com`
 - Auth header: `X-Api-Key: $HEYGEN_API_KEY`
 - Response format: `{ "error": null | string, "data": T }`
-- Video generation is async: generate returns `video_id`, poll `GET /v1/video_status.get` for completion
+- Video generation is async: generate returns `video_id`, poll `GET /v2/videos/{video_id}` for completion
 - MCP tools (`mcp__heygen__*`) are preferred over direct API calls when available

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ All skills use the HeyGen API:
 |----------|-------|---------|
 | `POST /v1/video_agent/generate` | heygen | One-shot prompt-to-video |
 | `POST /v2/video/generate` | heygen | Precise multi-scene video generation |
-| `GET /v1/video_status.get` | heygen | Check video generation status |
+| `GET /v2/videos/{video_id}` | heygen | Get video details and status |
+| `GET /v2/videos` | heygen | List account videos |
+| `DELETE /v2/videos/{video_id}` | heygen | Delete a video |
 | `GET /v2/avatars` | heygen | List available avatars |
 | `GET /v2/voices` | heygen | List available voices |
 | `POST /v1/audio/text_to_speech` | text-to-speech | Generate speech audio |

--- a/skills/heygen/SKILL.md
+++ b/skills/heygen/SKILL.md
@@ -23,9 +23,9 @@ If HeyGen MCP tools are available (`mcp__heygen__*`), **prefer them** over direc
 | Task | MCP Tool | Fallback (Direct API) |
 |------|----------|----------------------|
 | Generate video from prompt | `mcp__heygen__generate_video_agent` | `POST /v1/video_agent/generate` |
-| Check video status / get URL | `mcp__heygen__get_video` | `GET /v1/video_status.get` |
-| List account videos | `mcp__heygen__list_videos` | `GET /v1/video.list` |
-| Delete a video | `mcp__heygen__delete_video` | `DELETE /v1/video.delete` |
+| Check video status / get URL | `mcp__heygen__get_video` | `GET /v2/videos/{video_id}` |
+| List account videos | `mcp__heygen__list_videos` | `GET /v2/videos` |
+| Delete a video | `mcp__heygen__delete_video` | `DELETE /v2/videos/{video_id}` |
 
 If no HeyGen MCP tools are available, use direct HTTP API calls with `X-Api-Key: $HEYGEN_API_KEY` header as documented in the reference files.
 
@@ -42,7 +42,7 @@ Always use [prompt-optimizer.md](references/prompt-optimizer.md) guidelines to s
 **Without MCP tools (direct API):**
 1. Write an optimized prompt using [prompt-optimizer.md](references/prompt-optimizer.md) → [visual-styles.md](references/visual-styles.md)
 2. `POST /v1/video_agent/generate` — see [video-agent.md](references/video-agent.md)
-3. `GET /v1/video_status.get?video_id=<id>` — see [video-status.md](references/video-status.md)
+3. `GET /v2/videos/<id>` — see [video-status.md](references/video-status.md)
 
 Only use v2/video/generate when user explicitly needs:
 - Exact script without AI modification

--- a/skills/heygen/references/video-generation.md
+++ b/skills/heygen/references/video-generation.md
@@ -410,7 +410,7 @@ async function waitForVideo(videoId: string): Promise<string> {
 
   for (let i = 0; i < maxAttempts; i++) {
     const response = await fetch(
-      `https://api.heygen.com/v1/video_status.get?video_id=${videoId}`,
+      `https://api.heygen.com/v2/videos/${videoId}`,
       { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
     );
 
@@ -419,7 +419,7 @@ async function waitForVideo(videoId: string): Promise<string> {
     if (data.status === "completed") {
       return data.video_url;
     } else if (data.status === "failed") {
-      throw new Error(data.error || "Video generation failed");
+      throw new Error(data.failure_message || "Video generation failed");
     }
 
     await new Promise((r) => setTimeout(r, pollInterval));

--- a/skills/heygen/references/video-status.md
+++ b/skills/heygen/references/video-status.md
@@ -9,14 +9,14 @@ After generating a video, you need to poll for status until the video is complet
 
 ## MCP Tool (Preferred)
 
-If the HeyGen MCP server is connected, use `mcp__heygen__get_video` with the `videoId` parameter. It returns status, video_url, thumbnail_url, duration, and all metadata in a single call.
+If the HeyGen MCP server is connected, use `mcp__heygen__get_video` with the `videoId` parameter. It returns status, video_url, thumbnail_url, duration, title, gif_url, captioned_video_url, and other metadata in a single call.
 
 ## Checking Video Status (Direct API)
 
 ### curl
 
 ```bash
-curl -X GET "https://api.heygen.com/v1/video_status.get?video_id=YOUR_VIDEO_ID" \
+curl -X GET "https://api.heygen.com/v2/videos/YOUR_VIDEO_ID" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
@@ -26,18 +26,27 @@ curl -X GET "https://api.heygen.com/v1/video_status.get?video_id=YOUR_VIDEO_ID" 
 interface VideoStatusResponse {
   error: null | string;
   data: {
-    video_id: string;
+    id: string;
     status: "pending" | "processing" | "completed" | "failed";
     video_url?: string;
     thumbnail_url?: string;
     duration?: number;
-    error?: string;
+    title?: string;
+    created_at?: string;
+    completed_at?: string;
+    gif_url?: string;
+    captioned_video_url?: string;
+    subtitle_url?: string;
+    folder_id?: string;
+    output_language?: string;
+    failure_code?: string;
+    failure_message?: string;
   };
 }
 
 async function getVideoStatus(videoId: string): Promise<VideoStatusResponse["data"]> {
   const response = await fetch(
-    `https://api.heygen.com/v1/video_status.get?video_id=${videoId}`,
+    `https://api.heygen.com/v2/videos/${videoId}`,
     { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
   );
 
@@ -59,8 +68,7 @@ import os
 
 def get_video_status(video_id: str) -> dict:
     response = requests.get(
-        f"https://api.heygen.com/v1/video_status.get",
-        params={"video_id": video_id},
+        f"https://api.heygen.com/v2/videos/{video_id}",
         headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]}
     )
 
@@ -105,11 +113,19 @@ Video generation typically takes **5-15 minutes**, but can exceed 20 minutes dur
 {
   "error": null,
   "data": {
-    "video_id": "abc123",
+    "id": "abc123",
     "status": "completed",
     "video_url": "https://files.heygen.ai/video/abc123.mp4",
     "thumbnail_url": "https://files.heygen.ai/thumbnail/abc123.jpg",
-    "duration": 45.2
+    "duration": 45.2,
+    "title": "My Video",
+    "created_at": "2024-01-15T10:30:00Z",
+    "completed_at": "2024-01-15T10:38:00Z",
+    "gif_url": "https://files.heygen.ai/gif/abc123.gif",
+    "captioned_video_url": null,
+    "subtitle_url": null,
+    "folder_id": null,
+    "output_language": "en"
   }
 }
 ```
@@ -120,9 +136,10 @@ Video generation typically takes **5-15 minutes**, but can exceed 20 minutes dur
 {
   "error": null,
   "data": {
-    "video_id": "abc123",
+    "id": "abc123",
     "status": "failed",
-    "error": "Script too long for selected avatar"
+    "failure_code": "script_too_long",
+    "failure_message": "Script too long for selected avatar"
   }
 }
 ```
@@ -146,7 +163,7 @@ async function waitForVideo(
       case "completed":
         return status.video_url!;
       case "failed":
-        throw new Error(status.error || "Video generation failed");
+        throw new Error(status.failure_message || "Video generation failed");
       case "pending":
       case "processing":
         await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
@@ -181,7 +198,7 @@ async function waitForVideoWithProgress(
       case "completed":
         return status.video_url!;
       case "failed":
-        throw new Error(status.error || "Video generation failed");
+        throw new Error(status.failure_message || "Video generation failed");
       default:
         await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
     }
@@ -224,7 +241,7 @@ def wait_for_video(
         if status == "completed":
             return status_data["video_url"]
         elif status == "failed":
-            raise Exception(status_data.get("error", "Video generation failed"))
+            raise Exception(status_data.get("failure_message", "Video generation failed"))
 
         time.sleep(poll_interval)
 
@@ -431,11 +448,13 @@ async function checkVideoStatus(): Promise<void> {
         videoUrl: status.video_url,
         thumbnailUrl: status.thumbnail_url,
         duration: status.duration,
-        completedAt: new Date().toISOString(),
+        title: status.title,
+        createdAt: status.created_at,
+        completedAt: status.completed_at,
       }, null, 2));
       break;
     case "failed":
-      console.error(`Video failed: ${status.error}`);
+      console.error(`Video failed: ${status.failure_message}`);
       fs.unlinkSync("pending-video.json");
       break;
     default:


### PR DESCRIPTION
## Summary
- Replace three legacy v1 endpoints with RESTful v2 equivalents across all skill files:
  - `GET /v1/video_status.get?video_id=X` → `GET /v2/videos/{video_id}`
  - `GET /v1/video.list` → `GET /v2/videos`
  - `DELETE /v1/video.delete` → `DELETE /v2/videos/{video_id}`
- Update v2 response shape: `video_id` → `id`, `error` → `failure_code`/`failure_message`, add new fields (`title`, `created_at`, `completed_at`, `gif_url`, `captioned_video_url`, `subtitle_url`, `folder_id`, `output_language`)
- Update all code examples (curl, TypeScript, Python), JSON response samples, and polling logic across 5 files

## Test plan
- [ ] `grep -r "v1/video_status\|v1/video\.list\|v1/video\.delete" skills/ README.md CLAUDE.md` returns zero matches
- [ ] All `status.error` / `data.error` accesses in video-status.md and video-generation.md are now `failure_message`
- [ ] All URL constructions use path params (`/v2/videos/${videoId}`) not query params
- [ ] `video-translate` skill is untouched
- [ ] No cross-skill references introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)