### PR TITLE
Add video-download skill (yt-dlp CLI patterns)

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -67,3 +67,12 @@ jobs:
             --version 2.${{ github.run_number }}.0 \
             --tags latest,translation,dubbing,heygen,video-translate,localization,lip-sync \
             --changelog "Auto-publish from commit ${{ github.sha }}"
+
+      - name: Publish video-download skill
+        run: |
+          clawhub publish ./skills/video-download \
+            --slug video-download \
+            --name "Video Download" \
+            --version 2.${{ github.run_number }}.0 \
+            --tags latest,video,yt-dlp,download,youtube,audio,local \
+            --changelog "Auto-publish from commit ${{ github.sha }}"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A collection of skills for working with the HeyGen AI video creation API, design
 | [text-to-speech](skills/text-to-speech) | Generate standalone speech audio from text using HeyGen's Starfish TTS model with voice, speed, pitch, and emotion control |
 | [video-translate](skills/video-translate) | Translate and dub existing videos into 12+ languages with lip-sync, voice cloning, and multi-speaker support |
 | [visual-style](skills/visual-style) | Create, extract, and apply portable visual design systems (`visual-style.md`) across HeyGen, slides, Figma, and more |
+| [video-download](skills/video-download) | Download video and audio from YouTube and 1000+ sites using yt-dlp |
 | [heygen](skills/heygen) | *(Deprecated)* Legacy combined skill — use `create-video` or `avatar-video` instead |
 
 ## Installation
@@ -80,6 +81,8 @@ The skills should appear when Claude Code loads. You can verify by asking Claude
 | Create a visual design system | `visual-style` |
 | Extract a visual style from a website/video/PDF | `visual-style` |
 | Apply a visual style to HeyGen/slides/Figma | `visual-style` |
+| Download a video from YouTube or other sites | `video-download` |
+| Extract audio from a video URL | `video-download` |
 
 ## Example Prompts
 

--- a/skills/video-download/SKILL.md
+++ b/skills/video-download/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: video-download
+description: |
+  Download video and audio from YouTube and 1000+ sites using yt-dlp. No API keys needed.
+  Use when: (1) Downloading a video from YouTube or other sites, (2) Extracting audio from a video URL,
+  (3) Downloading subtitles/captions from a video, (4) Getting video metadata without downloading.
+---
+
+# video-download
+
+Download video and audio from URLs using yt-dlp directly. No wrapper scripts needed.
+
+## Prerequisites
+
+- **yt-dlp**: `brew install yt-dlp` or `pip install yt-dlp`
+- **ffmpeg**: `brew install ffmpeg` or `apt install ffmpeg` (required for merging video+audio streams)
+
+Update yt-dlp periodically to keep up with site changes: `yt-dlp -U` or `pip install -U yt-dlp`.
+
+## Commands
+
+### Download best quality
+
+```bash
+yt-dlp "URL" -o "%(title)s.%(ext)s" --merge-output-format mp4
+```
+
+### Download specific resolution
+
+```bash
+# 720p
+yt-dlp "URL" -f "bestvideo[height<=720]+bestaudio/best[height<=720]" --merge-output-format mp4
+
+# 1080p
+yt-dlp "URL" -f "bestvideo[height<=1080]+bestaudio/best[height<=1080]" --merge-output-format mp4
+```
+
+### Audio only
+
+```bash
+yt-dlp "URL" -x --audio-format mp3 --audio-quality 0
+```
+
+### Download subtitles
+
+```bash
+# Download video with English subtitles
+yt-dlp "URL" --write-subs --sub-langs en --merge-output-format mp4
+
+# Download video with multiple subtitle languages
+yt-dlp "URL" --write-subs --sub-langs "en,es,fr" --merge-output-format mp4
+
+# Download only subtitles (no video)
+yt-dlp "URL" --write-subs --sub-langs en --skip-download
+```
+
+### Get metadata (no download)
+
+```bash
+yt-dlp "URL" --dump-json --no-download
+```
+
+### List available formats
+
+```bash
+yt-dlp "URL" -F
+```
+
+### Specify output directory
+
+```bash
+yt-dlp "URL" -o "./downloads/%(title)s.%(ext)s" --merge-output-format mp4
+```
+
+## Quality Presets
+
+| Quality | Format flag |
+|---------|-------------|
+| Best | `-f "bestvideo+bestaudio/best"` (default) |
+| 1080p | `-f "bestvideo[height<=1080]+bestaudio/best[height<=1080]"` |
+| 720p | `-f "bestvideo[height<=720]+bestaudio/best[height<=720]"` |
+| 480p | `-f "bestvideo[height<=480]+bestaudio/best[height<=480]"` |
+| Worst | `-f "worstvideo+worstaudio/worst"` |
+
+## Output Template Variables
+
+Common variables for `-o` templates:
+
+| Variable | Description |
+|----------|-------------|
+| `%(title)s` | Video title |
+| `%(ext)s` | File extension |
+| `%(id)s` | Video ID |
+| `%(uploader)s` | Channel/uploader name |
+| `%(upload_date)s` | Upload date (YYYYMMDD) |
+| `%(duration)s` | Duration in seconds |
+| `%(resolution)s` | Video resolution |
+
+## Tips
+
+- Always use `--merge-output-format mp4` to avoid ending up with `.webm` or `.mkv` files.
+- Use `--no-download` with `--dump-json` for metadata-only queries -- no files written to disk.
+- If a download fails with HTTP errors, update yt-dlp first (`yt-dlp -U`).
+- Use `-f "bestvideo[height<=720]+bestaudio"` to save bandwidth when full resolution is not needed.
+- yt-dlp automatically handles rate limiting and retries.
+- The `--dump-json` output includes `title`, `duration`, `uploader`, `view_count`, `description`, `formats`, `subtitles`, and much more.
+
+## Troubleshooting
+
+- **"yt-dlp: command not found"**: Install it (`pip install yt-dlp`) and ensure your PATH includes pip's bin directory.
+- **"ffmpeg: command not found"**: Install ffmpeg. Without it, downloads fail when video and audio are separate streams (common on YouTube for HD).
+- **Downloads fail or return errors**: Run `yt-dlp -U` to update. Sites change frequently and yt-dlp ships fixes regularly.


### PR DESCRIPTION
## Summary

- Add `video-download` skill that teaches agents to use yt-dlp CLI directly — no wrapper scripts
- The skill's value is the CLI patterns, quality presets, output templates, and troubleshooting recipes
- Single-file skill: just `SKILL.md` (no `scripts/`, no `references/`)
- Updates README.md skills table and quick reference
- Adds ClawHub publish step to CI workflow

## What changed from v1

The original PR included Python wrapper scripts (`scripts/download_video.py`, `scripts/setup.py`) and reference docs (`references/`). This revision removes all of that. Agents are better served by learning yt-dlp directly rather than through a wrapper — it's more flexible, debuggable, and keeps the skill minimal.

## Skill teaches

- **Download best quality**: `yt-dlp "URL" -o "%(title)s.%(ext)s" --merge-output-format mp4`
- **Specific resolution**: `-f "bestvideo[height<=720]+bestaudio/best[height<=720]"`
- **Audio-only**: `-x --audio-format mp3 --audio-quality 0`
- **Subtitles**: `--write-subs --sub-langs en --merge-output-format mp4`
- **Metadata only**: `--dump-json --no-download`
- **Quality presets table** (best, 1080p, 720p, 480p, worst)
- **Output template variables** (`%(title)s`, `%(ext)s`, `%(uploader)s`, etc.)
- **Troubleshooting** (missing yt-dlp, missing ffmpeg, stale extractors)

## Test plan

- [ ] Verify `yt-dlp "URL" --merge-output-format mp4` downloads successfully
- [ ] Test audio-only extraction with `-x --audio-format mp3`
- [ ] Test metadata retrieval with `--dump-json --no-download`
- [ ] Test resolution selection with `-f "bestvideo[height<=720]+bestaudio"`
- [ ] Confirm CI workflow publishes skill to ClawHub
- [ ] Verify README.md skill table includes video-download entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)