### PR TITLE
Add auto-edit skill

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -67,3 +67,12 @@ jobs:
             --version 2.${{ github.run_number }}.0 \
             --tags latest,translation,dubbing,heygen,video-translate,localization,lip-sync \
             --changelog "Auto-publish from commit ${{ github.sha }}"
+
+      - name: Publish auto-edit skill
+        run: |
+          clawhub publish ./skills/auto-edit \
+            --slug auto-edit \
+            --name "Auto Edit" \
+            --version 2.${{ github.run_number }}.0 \
+            --tags latest,video,auto-editor,ffmpeg,whisper,silence-removal,filler-words,local \
+            --changelog "Auto-publish from commit ${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ build/
 # Test
 coverage/
 
+# Python
+__pycache__/
+
 # Temporary
 tmp/
 temp/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A collection of skills for working with the HeyGen AI video creation API, design
 | [text-to-speech](skills/text-to-speech) | Generate standalone speech audio from text using HeyGen's Starfish TTS model with voice, speed, pitch, and emotion control |
 | [video-translate](skills/video-translate) | Translate and dub existing videos into 12+ languages with lip-sync, voice cloning, and multi-speaker support |
 | [visual-style](skills/visual-style) | Create, extract, and apply portable visual design systems (`visual-style.md`) across HeyGen, slides, Figma, and more |
+| [auto-edit](skills/auto-edit) | Auto-edit video by removing silence and filler words using auto-editor and Whisper — no API keys needed |
 | [heygen](skills/heygen) | *(Deprecated)* Legacy combined skill — use `create-video` or `avatar-video` instead |
 
 ## Installation
@@ -80,6 +81,8 @@ The skills should appear when Claude Code loads. You can verify by asking Claude
 | Create a visual design system | `visual-style` |
 | Extract a visual style from a website/video/PDF | `visual-style` |
 | Apply a visual style to HeyGen/slides/Figma | `visual-style` |
+| Remove silence from a video | `auto-edit` |
+| Remove filler words (um, uh, like) | `auto-edit` |
 
 ## Example Prompts
 

--- a/skills/auto-edit/SKILL.md
+++ b/skills/auto-edit/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: auto-edit
+description: |
+  Auto-edit video by removing silence and filler words. Uses auto-editor CLI for silence removal
+  and Whisper for filler word detection. No API keys needed.
+  Use when: (1) Removing awkward pauses and silence from a video, (2) Cutting filler words like
+  "um", "uh", "like", (3) Tightening up a talking-head or podcast video, (4) Speed-ramping
+  silent sections instead of cutting them, (5) Combining silence removal with filler word removal.
+---
+
+# auto-edit
+
+Remove silence and filler words from video. Two tools, one workflow:
+
+- **auto-editor** — CLI tool for silence removal and rendering. Run it directly.
+- **detect_fillers.py** — Script that finds filler words via Whisper and outputs `--cut-out` flags for auto-editor.
+
+## Prerequisites
+
+**Required:** `ffmpeg` — `brew install ffmpeg`
+
+**Recommended:** `auto-editor` — handles silence detection + rendering in one pass.
+```bash
+pip install auto-editor   # or: brew install auto-editor
+auto-editor --version     # verify
+```
+See https://auto-editor.com/installing for other methods.
+
+**For filler detection:** `openai-whisper` — needed only for `detect_fillers.py`.
+```bash
+pip install openai-whisper
+whisper --help            # verify
+```
+
+## Workflows
+
+### 1. Remove silence (most common)
+
+Run auto-editor directly:
+
+```bash
+auto-editor video.mp4 -o video_edited.mp4 --no-open
+```
+
+Adjust sensitivity with `--edit` and `--margin`:
+
+```bash
+# More aggressive (lower threshold = catches more silence)
+auto-editor video.mp4 --edit "audio:0.02" --margin 0.1s -o output.mp4 --no-open
+
+# Less aggressive (higher threshold, wider margin)
+auto-editor video.mp4 --edit "audio:0.08" --margin 0.3s -o output.mp4 --no-open
+```
+
+Preview what would be cut (no rendering):
+
+```bash
+auto-editor video.mp4 --preview --no-open
+```
+
+### 2. Remove filler words
+
+Detect fillers first, then pass the cut ranges to auto-editor:
+
+```bash
+# Step 1: Detect fillers (outputs JSON with auto-editor flags)
+python3 skills/auto-edit/scripts/detect_fillers.py video.mp4
+
+# Step 2: Use the auto_editor_command from the JSON output, or manually:
+auto-editor video.mp4 --edit none --cut-out 9.63s,9.91s --cut-out 38.93s,39.39s -o output.mp4 --no-open
+```
+
+Custom filler word list:
+
+```bash
+python3 skills/auto-edit/scripts/detect_fillers.py video.mp4 --filler-words "um,uh,like,so"
+```
+
+### 3. Remove both silence and fillers
+
+Combine auto-editor's silence detection with filler word `--cut-out` flags:
+
+```bash
+# Step 1: Get filler cut flags
+python3 skills/auto-edit/scripts/detect_fillers.py video.mp4 -q
+
+# Step 2: Run auto-editor with silence detection + filler cuts
+auto-editor video.mp4 --edit "audio:0.04" --cut-out 9.63s,9.91s --cut-out 38.93s,39.39s -o output.mp4 --no-open
+```
+
+### 4. Speed-ramp silence (instead of cutting)
+
+Instead of removing silence entirely, speed it up for a smoother result:
+
+```bash
+# 3x speed through silence
+auto-editor video.mp4 --when-silent "speed:3" -o output.mp4 --no-open
+
+# 2x speed through silence, slight speedup of speech too
+auto-editor video.mp4 --when-silent "speed:2" --when-normal "speed:1.1" -o output.mp4 --no-open
+```
+
+### 5. Without auto-editor (ffmpeg fallback)
+
+If auto-editor is not installed, use ffmpeg's silencedetect filter to find silent segments, then trim and concat:
+
+```bash
+# Detect silence
+ffmpeg -i video.mp4 -af "silencedetect=noise=0.04:d=0.5" -f null - 2>&1 | grep "silence_"
+
+# Then use video-edit skill to trim and concat the keep segments
+```
+
+See `references/ffmpeg-fallback.md` for the full ffmpeg-based workflow.
+
+## detect_fillers.py Reference
+
+| Flag | Description |
+|------|-------------|
+| `input` | Input video or audio file (positional) |
+| `--whisper-model` | tiny, base (default), small, medium, large |
+| `--filler-words` | Comma-separated custom list |
+| `--padding` | Seconds of padding around cuts (default: 0.05) |
+| `-o, --output` | Write JSON to file |
+| `-q, --quiet` | JSON only, no progress |
+
+Output includes ready-to-use `auto_editor_command` and `auto_editor_flags` fields.
+
+Default filler words: um, uh, uhh, umm, hmm, hm, like, you know, basically, actually, literally, right, so, i mean
+
+## auto-editor Quick Reference
+
+See `references/auto-editor-guide.md` for the full CLI reference.
+
+| What | Command |
+|------|---------|
+| Remove silence | `auto-editor video.mp4 -o out.mp4 --no-open` |
+| Adjust threshold | `--edit "audio:0.04"` (default), lower=more sensitive |
+| Adjust margin | `--margin 0.2s` (default), padding around speech |
+| Cut specific ranges | `--cut-out 5.2s,6.8s` (repeat for multiple) |
+| Speed-ramp silence | `--when-silent "speed:3"` |
+| Preview (no render) | `--preview --no-open` |
+| Quiet mode | `-q` |
+
+## References
+
+- `references/auto-editor-guide.md` — Full auto-editor CLI reference and advanced usage
+- `references/ffmpeg-fallback.md` — Silence detection and rendering without auto-editor

--- a/skills/auto-edit/references/auto-editor-guide.md
+++ b/skills/auto-edit/references/auto-editor-guide.md
@@ -1,0 +1,150 @@
+# auto-editor CLI Reference
+
+[auto-editor](https://auto-editor.com) is an open-source tool for automatically editing video based on audio levels, motion, or subtitles. This skill uses it as the preferred rendering backend.
+
+## Installation
+
+```bash
+# macOS (recommended)
+brew install auto-editor
+
+# pip
+pip install auto-editor
+
+# Verify
+auto-editor --version
+```
+
+See full install guide: https://auto-editor.com/installing
+
+## How This Skill Uses auto-editor
+
+### Silence removal only
+
+```bash
+auto-editor video.mp4 --edit "audio:0.04" --margin 0.2s -o output.mp4 --no-open
+```
+
+### Silence + filler word removal
+
+Filler word time ranges (from Whisper) are injected via `--cut-out`:
+
+```bash
+auto-editor video.mp4 --edit "audio:0.04" --margin 0.2s \
+  --cut-out 9.63s,9.91s --cut-out 38.93s,39.39s \
+  -o output.mp4 --no-open
+```
+
+### Filler words only (no silence removal)
+
+```bash
+auto-editor video.mp4 --edit none \
+  --cut-out 9.63s,9.91s --cut-out 38.93s,39.39s \
+  -o output.mp4 --no-open
+```
+
+## Key CLI Options
+
+### `--edit METHOD`
+
+Controls how auto-editor decides what to cut. Sugar syntax:
+
+```
+--edit "audio:THRESHOLD"
+--edit "audio:0.04,stream=0"
+--edit "motion:0.02"
+--edit "none"                   # Don't auto-detect, only use --cut-out
+```
+
+**Audio parameters:**
+| Param | Default | Description |
+|-------|---------|-------------|
+| threshold | 0.04 | Amplitude threshold (0.0-1.0). Lower = more sensitive |
+| stream | all | Which audio stream(s) to analyze |
+| mincut | 6 | Minimum cut length (in timebase frames) |
+| minclip | 3 | Minimum clip length (in timebase frames) |
+
+### `--margin LENGTH`
+
+Sets how much padding to keep around "loud" sections. Prevents cuts from landing right at the edge of speech.
+
+```
+--margin 0.2s    # 200ms (default)
+--margin 0.1s    # Tighter cuts
+--margin 0.5s    # More breathing room
+```
+
+### `--cut-out START,STOP`
+
+Cut a specific time range. Can be repeated for multiple ranges:
+
+```
+--cut-out 5.2s,6.8s --cut-out 12.1s,12.6s
+```
+
+Time values must include the `s` suffix for seconds.
+
+### `--when-silent ACTION`
+
+What to do with silent sections (default: `cut`):
+
+```
+--when-silent cut              # Remove completely (default)
+--when-silent "speed:2"        # Speed up 2x instead of cutting
+--when-silent "speed:3"        # Speed up 3x
+```
+
+### `--when-normal ACTION`
+
+What to do with non-silent sections (default: `nil` / unchanged):
+
+```
+--when-normal nil              # Keep as-is (default)
+--when-normal "speed:1.2"     # Slight speedup of speech
+```
+
+### `--preview` / `--stats`
+
+Preview what would be cut without rendering:
+
+```bash
+auto-editor video.mp4 --preview --no-open
+```
+
+Shows clip count, cut count, and duration stats.
+
+### Output options
+
+```
+-o, --output FILE        Output file path
+--no-open                Don't auto-open output after rendering
+-q, --quiet              Less output
+--debug                  Verbose debug output
+```
+
+## Advanced: Speed Ramping Instead of Cutting
+
+Instead of removing silence entirely, speed it up:
+
+```bash
+# 3x speed through silence
+auto-editor video.mp4 --when-silent "speed:3" -o output.mp4 --no-open
+
+# 2x speed through silence, slight speedup of speech
+auto-editor video.mp4 --when-silent "speed:2" --when-normal "speed:1.1" -o output.mp4 --no-open
+```
+
+## Advanced: Motion-Based Editing
+
+Edit based on visual motion instead of audio:
+
+```bash
+auto-editor video.mp4 --edit "motion:0.02" -o output.mp4 --no-open
+```
+
+## Docs
+
+- Install guide: https://auto-editor.com/installing
+- Full docs: https://auto-editor.com/docs/
+- Edit flag reference: https://auto-editor.com/ref/edit
+- GitHub: https://github.com/WyattBlue/auto-editor

--- a/skills/auto-edit/references/ffmpeg-fallback.md
+++ b/skills/auto-edit/references/ffmpeg-fallback.md
@@ -1,0 +1,40 @@
+# Silence Removal with ffmpeg (No auto-editor)
+
+When auto-editor is not installed, use ffmpeg directly for silence detection and removal.
+
+## Step 1: Detect silence
+
+```bash
+ffmpeg -i video.mp4 -af "silencedetect=noise=0.04:d=0.5" -f null - 2>&1 | grep "silence_"
+```
+
+Parameters:
+- `noise=0.04` — amplitude threshold (0.0-1.0). Lower = catches more silence.
+- `d=0.5` — minimum silence duration in seconds.
+
+Output lines look like:
+```
+[silencedetect @ 0x...] silence_start: 5.2
+[silencedetect @ 0x...] silence_end: 6.8 | silence_duration: 1.6
+```
+
+## Step 2: Trim and concat keep segments
+
+Use the video-edit skill or ffmpeg directly to trim out the keep segments and concat them:
+
+```bash
+# Trim each keep segment to MPEG-TS
+ffmpeg -y -ss 0 -to 5.2 -i video.mp4 -c:v libx264 -preset fast -c:a aac -f mpegts seg_0.ts
+ffmpeg -y -ss 6.8 -to 45.0 -i video.mp4 -c:v libx264 -preset fast -c:a aac -f mpegts seg_1.ts
+
+# Concat
+ffmpeg -y -i "concat:seg_0.ts|seg_1.ts" -c copy output.mp4
+```
+
+## Limitations vs auto-editor
+
+- **No frame-accurate cuts** — ffmpeg's `-ss` with `-c copy` seeks to the nearest keyframe. Re-encoding (shown above) gives accurate cuts but is slower.
+- **No margin control** — you must manually adjust the keep segment boundaries.
+- **More manual work** — auto-editor handles detection + rendering in one pass.
+
+Install auto-editor for better results: `pip install auto-editor` or `brew install auto-editor`.

--- a/skills/auto-edit/scripts/detect_fillers.py
+++ b/skills/auto-edit/scripts/detect_fillers.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Detect filler words in video/audio using Whisper word-level timestamps.
+
+Outputs JSON with filler word locations and ready-to-use auto-editor --cut-out
+flags. Feed the output directly into auto-editor or use the time ranges with
+ffmpeg for manual editing.
+
+Usage:
+  python3 detect_fillers.py video.mp4
+  python3 detect_fillers.py video.mp4 --filler-words "um,uh,like"
+  python3 detect_fillers.py video.mp4 --whisper-model small
+  python3 detect_fillers.py video.mp4 -q   # JSON only
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+DEFAULT_FILLER_WORDS = {
+    "um", "uh", "uhh", "umm", "hmm", "hm",
+    "like", "you know", "basically", "actually",
+    "literally", "right", "so", "i mean",
+}
+
+
+def die(message: str) -> None:
+    print(json.dumps({"error": message}, indent=2))
+    sys.exit(1)
+
+
+def log(msg: str, quiet: bool = False) -> None:
+    if not quiet:
+        print(msg, file=sys.stderr)
+
+
+def get_duration(path: str) -> float:
+    cmd = [
+        "ffprobe", "-v", "quiet",
+        "-print_format", "json",
+        "-show_format",
+        path,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        data = json.loads(result.stdout)
+        return float(data["format"]["duration"])
+    except Exception as exc:
+        die(f"Could not determine duration of {path}: {exc}")
+
+
+def transcribe(input_path: str, model: str = "base", quiet: bool = False) -> list[dict]:
+    """Transcribe audio and return word-level timestamps."""
+    log(f"Transcribing with Whisper (model={model})...", quiet)
+
+    fd, wav_path = tempfile.mkstemp(suffix=".wav", prefix="whisper_")
+    os.close(fd)
+
+    try:
+        # Extract audio
+        cmd = [
+            "ffmpeg", "-y", "-i", input_path,
+            "-vn", "-acodec", "pcm_s16le",
+            "-ar", "16000", "-ac", "1",
+            wav_path,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if result.returncode != 0:
+            die(f"ffmpeg audio extraction failed: {result.stderr.strip()[-200:]}")
+
+        # Try whisper Python module (faster)
+        try:
+            import whisper
+            model_obj = whisper.load_model(model)
+            result = model_obj.transcribe(wav_path, word_timestamps=True)
+
+            words = []
+            for segment in result.get("segments", []):
+                for w in segment.get("words", []):
+                    words.append({
+                        "word": w["word"].strip(),
+                        "start": round(w["start"], 3),
+                        "end": round(w["end"], 3),
+                    })
+            log(f"Transcribed {len(words)} words.", quiet)
+            return words
+        except ImportError:
+            pass
+
+        # Fall back to whisper CLI
+        if shutil.which("whisper") is None:
+            die(
+                "Whisper is not installed.\n"
+                "Install with: pip install openai-whisper"
+            )
+
+        json_dir = tempfile.mkdtemp(prefix="whisper_out_")
+        try:
+            cmd = [
+                "whisper", wav_path,
+                "--model", model,
+                "--output_format", "json",
+                "--word_timestamps", "True",
+                "--output_dir", json_dir,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+            if result.returncode != 0:
+                die(f"Whisper failed: {result.stderr.strip()[-200:]}")
+
+            json_files = list(Path(json_dir).glob("*.json"))
+            if not json_files:
+                die("Whisper produced no JSON output.")
+
+            with open(json_files[0]) as f:
+                data = json.load(f)
+
+            words = []
+            for segment in data.get("segments", []):
+                for w in segment.get("words", []):
+                    words.append({
+                        "word": w["word"].strip(),
+                        "start": round(w["start"], 3),
+                        "end": round(w["end"], 3),
+                    })
+            log(f"Transcribed {len(words)} words.", quiet)
+            return words
+        finally:
+            shutil.rmtree(json_dir, ignore_errors=True)
+    finally:
+        try:
+            os.unlink(wav_path)
+        except OSError:
+            pass
+
+
+def find_fillers(
+    words: list[dict],
+    filler_words: set[str],
+    padding: float = 0.05,
+) -> list[dict]:
+    """Match words against filler word list. Returns time-stamped matches."""
+    fillers = []
+
+    # Single-word fillers
+    for w in words:
+        cleaned = w["word"].lower().strip(".,!?;:'\"")
+        if cleaned in filler_words:
+            fillers.append({
+                "word": cleaned,
+                "start": round(max(0, w["start"] - padding), 3),
+                "end": round(w["end"] + padding, 3),
+            })
+
+    # Multi-word fillers (e.g., "you know", "i mean")
+    multi_word = {f for f in filler_words if " " in f}
+    for i in range(len(words) - 1):
+        for mwf in multi_word:
+            parts = mwf.split()
+            if i + len(parts) > len(words):
+                continue
+            candidate = " ".join(
+                words[i + j]["word"].lower().strip(".,!?;:'\"")
+                for j in range(len(parts))
+            )
+            if candidate == mwf:
+                fillers.append({
+                    "word": mwf,
+                    "start": round(max(0, words[i]["start"] - padding), 3),
+                    "end": round(words[i + len(parts) - 1]["end"] + padding, 3),
+                })
+
+    return fillers
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="detect_fillers.py",
+        description="Detect filler words in video/audio using Whisper.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+examples:
+  %(prog)s video.mp4
+  %(prog)s video.mp4 --filler-words "um,uh,like"
+  %(prog)s video.mp4 --whisper-model small
+  %(prog)s video.mp4 -q  # JSON only, no progress
+""",
+    )
+    parser.add_argument("input", help="Input video or audio file")
+    parser.add_argument(
+        "--whisper-model", default="base",
+        choices=["tiny", "base", "small", "medium", "large"],
+        help="Whisper model size (default: base)",
+    )
+    parser.add_argument(
+        "--filler-words",
+        help="Comma-separated filler words (default: um,uh,like,you know,...)",
+    )
+    parser.add_argument(
+        "--padding", type=float, default=0.05,
+        help="Seconds of padding around each filler cut (default: 0.05)",
+    )
+    parser.add_argument(
+        "-o", "--output", help="Write result JSON to file instead of stdout",
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true",
+        help="Suppress progress messages, output only JSON",
+    )
+
+    args = parser.parse_args()
+
+    input_path = os.path.abspath(args.input)
+    if not os.path.isfile(input_path):
+        die(f"Input file not found: {input_path}")
+
+    # Check deps
+    if shutil.which("ffmpeg") is None:
+        die("ffmpeg is not installed. Install with: brew install ffmpeg")
+
+    # Transcribe
+    words = transcribe(input_path, model=args.whisper_model, quiet=args.quiet)
+
+    # Find fillers
+    filler_words = DEFAULT_FILLER_WORDS.copy()
+    if args.filler_words:
+        filler_words = {w.strip().lower() for w in args.filler_words.split(",")}
+
+    fillers = find_fillers(words, filler_words, padding=args.padding)
+    log(f"Found {len(fillers)} filler word instances.", args.quiet)
+
+    # Build auto-editor --cut-out flags
+    cut_out_flags = []
+    for f in fillers:
+        cut_out_flags.append(f"--cut-out {f['start']}s,{f['end']}s")
+
+    # Build result
+    duration = get_duration(input_path)
+    filler_duration = sum(f["end"] - f["start"] for f in fillers)
+
+    result = {
+        "input": input_path,
+        "duration": round(duration, 2),
+        "word_count": len(words),
+        "fillers": fillers,
+        "filler_count": len(fillers),
+        "filler_duration": round(filler_duration, 2),
+        "auto_editor_flags": " ".join(cut_out_flags),
+        "auto_editor_command": (
+            f"auto-editor {input_path} {' '.join(cut_out_flags)} -o output.mp4 --no-open"
+            if cut_out_flags else None
+        ),
+    }
+
+    output = json.dumps(result, indent=2)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+        log(f"Written to {args.output}", args.quiet)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **auto-editor for silence removal** — the skill teaches agents to run the `auto-editor` CLI directly for silence detection and removal in one pass, with tunable threshold/margin parameters and speed-ramp alternatives
- **detect_fillers.py for filler word detection** — Python script that uses Whisper word-level timestamps to find filler words (um, uh, like, you know, etc.) and outputs ready-to-use `--cut-out` flags for auto-editor
- **Combined workflow** — silence removal + filler word removal in a single auto-editor invocation by merging `--edit "audio:..."` with `--cut-out` flags from the filler detector
- **ffmpeg fallback** — reference doc covering silence detection and segment-based trimming/concat when auto-editor is not installed
- **No API keys needed** — entirely local tooling (auto-editor, ffmpeg, Whisper)

## Changes

- `skills/auto-edit/SKILL.md` — skill manifest with workflows for silence removal, filler detection, combined editing, speed-ramping, and ffmpeg fallback
- `skills/auto-edit/scripts/detect_fillers.py` — Whisper-based filler word detector with JSON output
- `skills/auto-edit/references/auto-editor-guide.md` — full auto-editor CLI reference
- `skills/auto-edit/references/ffmpeg-fallback.md` — ffmpeg-only workflow when auto-editor unavailable
- `README.md` — added auto-edit to skills table and quick reference
- `.github/workflows/publish-clawhub.yml` — added publish step for auto-edit
- `.gitignore` — added `__pycache__/`

## Test plan

- [x] Tested end-to-end: silence removal with auto-editor, filler detection with detect_fillers.py, combined workflow
- [ ] Verify skill loads correctly in Claude Code (`/skills list`)
- [ ] Verify ClawHub publish step runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)