### PR TITLE
Rewrite generate-captions skill for local-first CLI workflow

### DIFF
--- a/skills/generate-captions/SKILL.md
+++ b/skills/generate-captions/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: generate-captions
+description: |
+  Generate styled captions for video using local Whisper transcription and ASS subtitles.
+  Use when: (1) Adding captions/subtitles to a video, (2) Creating TikTok/Reels-style word-by-word captions,
+  (3) Transcribing video with word-level timestamps, (4) Previewing and editing captions before final render.
+---
+
+# Generate Captions Skill
+
+Local-first caption generation: transcribe with Whisper, style with presets or CLI flags, burn in with ffmpeg.
+
+## Workflow
+
+```bash
+# 1. Transcribe → JSON (word-level timestamps)
+python3 scripts/caption_video.py video.mp4 --transcribe-only
+
+# 2. Style + generate ASS (preset or custom)
+python3 scripts/caption_video.py video.mp4 --json captions.json --style pop
+python3 scripts/caption_video.py video.mp4 --json captions.json --style pop --font-size 72 --primary-color "#FF0000"
+
+# 3. (Optional) Preview in browser
+python3 scripts/generate_preview.py captions.json --video video.mp4
+python3 -m http.server 8123 --directory output/
+
+# 4. Burn captions into video (just ffmpeg)
+ffmpeg -y -i video.mp4 -vf "ass=captions.ass" -c:a copy captioned.mp4
+
+# 5. Or use your own ASS file
+ffmpeg -y -i video.mp4 -vf "ass=custom.ass" -c:a copy captioned.mp4
+```
+
+## Style Presets
+
+| Preset | Position | Animation | Key Visual |
+|--------|----------|-----------|------------|
+| `classic` | bottom | karaoke-sweep | White text, black outline, orange highlight. Standard subtitles. |
+| `pop` | center | karaoke-sweep | White text, mint highlight, outline+shadow. TikTok style. |
+| `bold` | center | karaoke-sweep | Large text, gold highlight, high impact. |
+| `boxed` | center | karaoke-sweep | White text on black semi-transparent box, cyan highlight. |
+| `single` | center | karaoke-sweep | One word at a time, purple highlight, outline+shadow. |
+
+See [references/style-presets.md](references/style-presets.md) for full preset details.
+
+## CLI Flags
+
+### Mode
+
+| Flag | Description |
+|------|-------------|
+| `video` | Input video file (positional) |
+| `--transcribe-only` | Only transcribe → captions.json (skip ASS generation) |
+| `--json FILE` | Load existing caption JSON (skip transcription) |
+| `--list-styles` | List all presets and exit |
+
+### Whisper
+
+| Flag | Description |
+|------|-------------|
+| `--model` | Whisper model size: tiny, base, small, medium, large (default: base) |
+
+### Style Overrides
+
+All override flags take precedence over preset defaults and JSON style values.
+
+| Flag | Description |
+|------|-------------|
+| `--style` | Preset name: classic, pop, bold, boxed, single |
+| `--font-family` | Font family name |
+| `--font-size` | Font size in pt |
+| `--primary-color` | Base text color (`#RRGGBB`) |
+| `--secondary-color` | Highlight/active word color (`#RRGGBB`) |
+| `--outline-color` | Outline color (`#RRGGBB`) |
+| `--outline-width` | Outline width in px |
+| `--shadow-depth` | Drop shadow depth in px (0=none) |
+| `--background-color` | Background box color (`#RRGGBB`, enables boxed mode) |
+| `--position` | Caption position: bottom, center, top |
+| `--animation` | Animation: none, karaoke, karaoke-sweep |
+| `--words-per-line` | Max words per display chunk |
+| `--single-words` | Show one word at a time |
+
+### Output
+
+| Flag | Description |
+|------|-------------|
+| `--output-dir DIR` | Output directory (default: same as video) |
+| `-o, --output FILE` | Write result JSON to file instead of stdout |
+| `-q, --quiet` | Suppress progress messages |
+
+## Color Semantics
+
+- `primary_color` — base text color (what you see most of the time)
+- `secondary_color` — highlight/active word color (the karaoke sweep target)
+
+In the ASS file, these map to ASS PrimaryColour (highlight) and SecondaryColour (base) respectively, since ASS karaoke sweeps _from_ secondary _to_ primary.
+
+## Caption JSON Schema
+
+```json
+{
+  "video_path": "/abs/path/video.mp4",
+  "resolution": { "width": 1920, "height": 1080 },
+  "duration": 120.5,
+  "style": {
+    "preset": "pop",
+    "font_family": "Arial Black",
+    "font_size": 60,
+    "primary_color": "#FFFFFF",
+    "secondary_color": "#00FFB2",
+    "outline_color": "#000000",
+    "outline_width": 3,
+    "shadow_depth": 2,
+    "background_color": null,
+    "position": "center",
+    "animation": "karaoke-sweep",
+    "words_per_line": 4,
+    "single_words": false
+  },
+  "segments": [
+    {
+      "start": 0.0,
+      "end": 3.5,
+      "text": "Hello world this is a test",
+      "words": [
+        { "text": "Hello", "start": 0.0, "end": 0.4 },
+        { "text": "world", "start": 0.5, "end": 0.9 }
+      ]
+    }
+  ]
+}
+```
+
+## Dependencies
+
+- **FFmpeg + FFprobe** (system) — audio extraction, video burn-in
+- **openai-whisper** (pip) — transcription (auto-installed on first run)
+
+No pysubs2 dependency. ASS files are generated as raw strings for full control.
+
+## ASS Format Reference
+
+The generated ASS uses [Advanced SubStation Alpha v4+](https://fileformats.fandom.com/wiki/SubStation_Alpha#Advanced_SubStation_Alpha).
+
+- `\kf<cs>` — karaoke sweep (smooth fill over centiseconds)
+- `\k<cs>` — karaoke instant (fill at start of duration)
+- Background boxes use a two-layer approach: `DefaultBG` style (BorderStyle=3, opaque box) on layer 0, `Default` style (text+outline) on layer 1

--- a/skills/generate-captions/references/style-presets.md
+++ b/skills/generate-captions/references/style-presets.md
@@ -1,0 +1,123 @@
+# Style Presets
+
+## classic
+
+Standard subtitles at the bottom. White text with black outline, orange highlight on the active word.
+
+| Property | Value |
+|----------|-------|
+| Font | Arial, 48pt |
+| Primary (text) | `#FFFFFF` (white) |
+| Secondary (highlight) | `#FFA500` (orange) |
+| Outline | `#000000`, 3px |
+| Shadow | 0 |
+| Background | none |
+| Position | bottom |
+| Animation | karaoke-sweep |
+| Words/line | 6 |
+
+## pop
+
+TikTok / Reels style. Centered, mint highlight, outline + drop shadow.
+
+| Property | Value |
+|----------|-------|
+| Font | Arial Black, 60pt |
+| Primary (text) | `#FFFFFF` (white) |
+| Secondary (highlight) | `#00FFB2` (mint) |
+| Outline | `#000000`, 3px |
+| Shadow | 2px |
+| Background | none |
+| Position | center |
+| Animation | karaoke-sweep |
+| Words/line | 4 |
+
+## bold
+
+Large, high-impact captions with gold highlight.
+
+| Property | Value |
+|----------|-------|
+| Font | Arial Black, 72pt |
+| Primary (text) | `#FFFFFF` (white) |
+| Secondary (highlight) | `#FFD700` (gold) |
+| Outline | `#000000`, 4px |
+| Shadow | 3px |
+| Background | none |
+| Position | center |
+| Animation | karaoke-sweep |
+| Words/line | 3 |
+
+## boxed
+
+White text on a semi-transparent black box. Cyan highlight. Clean, readable over any background.
+
+| Property | Value |
+|----------|-------|
+| Font | Arial, 52pt |
+| Primary (text) | `#FFFFFF` (white) |
+| Secondary (highlight) | `#00E5FF` (cyan) |
+| Outline | `#000000`, 0px |
+| Shadow | 0 |
+| Background | `#000000` (semi-transparent) |
+| Position | center |
+| Animation | karaoke-sweep |
+| Words/line | 5 |
+
+The boxed preset generates a two-layer ASS file: a `DefaultBG` style (BorderStyle=3, opaque box) on layer 0, and the `Default` text style on layer 1.
+
+## single
+
+One word at a time, centered. Purple highlight with outline + shadow.
+
+| Property | Value |
+|----------|-------|
+| Font | Arial Black, 64pt |
+| Primary (text) | `#FFFFFF` (white) |
+| Secondary (highlight) | `#AA44FF` (purple) |
+| Outline | `#000000`, 3px |
+| Shadow | 2px |
+| Background | none |
+| Position | center |
+| Animation | karaoke-sweep |
+| Words/line | 1 (single_words=true) |
+
+## Animation Types
+
+### none
+Words appear as plain text. No word-level highlighting. Primary color used for all text.
+
+### karaoke
+Words are highlighted instantly as spoken. Uses ASS `\k` tag. The secondary color fills each word at the moment it starts.
+
+### karaoke-sweep
+Words are highlighted with a smooth left-to-right sweep. Uses ASS `\kf` tag. The secondary color sweeps across each word over its duration.
+
+## Color Semantics
+
+- **primary_color** — base text color (what you see most of the time)
+- **secondary_color** — highlight / active word color (the karaoke sweep fills with this)
+
+Colors are specified as `#RRGGBB` hex strings. Internally converted to ASS BGR format (`&HAABBGGRR`).
+
+## Ad-Hoc Boxed Mode
+
+Any preset can be given a background box by passing `--background-color`:
+
+```bash
+python3 caption_video.py video.mp4 --json captions.json --style classic --background-color "#000000"
+```
+
+This adds the `DefaultBG` layer to the ASS output regardless of the base preset.
+
+## Position Values
+
+| Value | ASS Alignment | Description |
+|-------|--------------|-------------|
+| bottom | 2 | Bottom center (standard subtitle position) |
+| center | 5 | Middle center (social media style) |
+| top | 8 | Top center |
+
+## Portrait Video
+
+For portrait/vertical videos (height > width), margins are automatically increased (80px vertical, 60px horizontal) to keep captions clear of safe zones.

--- a/skills/generate-captions/scripts/caption_video.py
+++ b/skills/generate-captions/scripts/caption_video.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""Transcribe video and generate styled ASS subtitles.
+
+Two modes:
+  1. Transcribe-only:  video → Whisper → captions.json
+  2. Style + ASS:      captions.json + style → captions.ass
+
+Examples:
+    # Transcribe to JSON
+    python3 caption_video.py video.mp4 --transcribe-only
+
+    # Generate ASS from JSON with a preset
+    python3 caption_video.py video.mp4 --json captions.json --style pop
+
+    # Override preset values via CLI
+    python3 caption_video.py video.mp4 --json captions.json --style pop \
+        --font-size 72 --primary-color "#FF0000"
+
+    # List presets
+    python3 caption_video.py --list-styles
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+# ---------------------------------------------------------------------------
+# Presets
+# ---------------------------------------------------------------------------
+
+PRESETS = {
+    "classic": {
+        "font_family": "Arial",
+        "font_size": 48,
+        "primary_color": "#FFFFFF",
+        "secondary_color": "#FFA500",
+        "outline_color": "#000000",
+        "outline_width": 3,
+        "shadow_depth": 0,
+        "background_color": None,
+        "position": "bottom",
+        "animation": "karaoke-sweep",
+        "words_per_line": 6,
+        "single_words": False,
+    },
+    "pop": {
+        "font_family": "Arial Black",
+        "font_size": 60,
+        "primary_color": "#FFFFFF",
+        "secondary_color": "#00FFB2",
+        "outline_color": "#000000",
+        "outline_width": 3,
+        "shadow_depth": 2,
+        "background_color": None,
+        "position": "center",
+        "animation": "karaoke-sweep",
+        "words_per_line": 4,
+        "single_words": False,
+    },
+    "bold": {
+        "font_family": "Arial Black",
+        "font_size": 72,
+        "primary_color": "#FFFFFF",
+        "secondary_color": "#FFD700",
+        "outline_color": "#000000",
+        "outline_width": 4,
+        "shadow_depth": 3,
+        "background_color": None,
+        "position": "center",
+        "animation": "karaoke-sweep",
+        "words_per_line": 3,
+        "single_words": False,
+    },
+    "boxed": {
+        "font_family": "Arial",
+        "font_size": 52,
+        "primary_color": "#FFFFFF",
+        "secondary_color": "#00E5FF",
+        "outline_color": "#000000",
+        "outline_width": 0,
+        "shadow_depth": 0,
+        "background_color": "#000000",
+        "position": "center",
+        "animation": "karaoke-sweep",
+        "words_per_line": 5,
+        "single_words": False,
+    },
+    "single": {
+        "font_family": "Arial Black",
+        "font_size": 64,
+        "primary_color": "#FFFFFF",
+        "secondary_color": "#AA44FF",
+        "outline_color": "#000000",
+        "outline_width": 3,
+        "shadow_depth": 2,
+        "background_color": None,
+        "position": "center",
+        "animation": "karaoke-sweep",
+        "words_per_line": 1,
+        "single_words": True,
+    },
+}
+
+ALIGNMENT_MAP = {"bottom": 2, "center": 5, "top": 8}
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+_quiet = False
+
+
+def log(msg):
+    if not _quiet:
+        print(f"[captions] {msg}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Color helpers
+# ---------------------------------------------------------------------------
+
+def hex_to_ass_color(hex_color, alpha=0):
+    """Convert '#RRGGBB' → '&HAABBGGRR' (ASS uses BGR order)."""
+    h = hex_color.lstrip("#")
+    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return f"&H{alpha:02X}{b:02X}{g:02X}{r:02X}"
+
+
+# ---------------------------------------------------------------------------
+# Style resolution  (3-tier: CLI flags > JSON style > preset defaults)
+# ---------------------------------------------------------------------------
+
+def resolve_style(cli_args, json_style=None):
+    """Merge preset defaults, JSON style section, and CLI flag overrides.
+
+    Returns the final style dict.
+    """
+    preset_name = cli_args.style or (json_style or {}).get("preset", "classic")
+    if preset_name not in PRESETS:
+        raise ValueError(
+            f"Unknown preset '{preset_name}'. Available: {', '.join(PRESETS)}"
+        )
+    style = dict(PRESETS[preset_name])
+    style["preset"] = preset_name
+
+    # Layer 2: JSON style overrides (from captions.json)
+    if json_style:
+        for k, v in json_style.items():
+            if k != "preset" and v is not None:
+                style[k] = v
+
+    # Layer 3: CLI flag overrides
+    flag_map = {
+        "font_family": "font_family",
+        "font_size": "font_size",
+        "primary_color": "primary_color",
+        "secondary_color": "secondary_color",
+        "outline_color": "outline_color",
+        "outline_width": "outline_width",
+        "shadow_depth": "shadow_depth",
+        "background_color": "background_color",
+        "position": "position",
+        "animation": "animation",
+        "words_per_line": "words_per_line",
+        "single_words": "single_words",
+    }
+    for attr, key in flag_map.items():
+        val = getattr(cli_args, attr, None)
+        if val is not None:
+            style[key] = val
+
+    # --single-words is a store_true flag; only override if explicitly set
+    if getattr(cli_args, "single_words", False):
+        style["single_words"] = True
+
+    return style
+
+
+# ---------------------------------------------------------------------------
+# Smart chunking
+# ---------------------------------------------------------------------------
+
+_SENTENCE_ENDERS = {".", "!", "?"}
+_CLAUSE_BREAKS = {",", ";", ":", "\u2014", "\u2013", "-"}
+_PAUSE_THRESHOLD = 0.5
+
+
+def smart_chunk_words(words, max_words=4):
+    """Split words into display chunks on natural language breaks."""
+    if max_words <= 1:
+        return [[w] for w in words]
+
+    chunks, cur = [], []
+    for i, word in enumerate(words):
+        cur.append(word)
+        text = word.get("text", "").rstrip()
+        is_sent = any(text.endswith(p) for p in _SENTENCE_ENDERS)
+        is_clause = any(text.endswith(p) for p in _CLAUSE_BREAKS)
+        has_pause = (
+            i < len(words) - 1
+            and (words[i + 1]["start"] - word["end"]) >= _PAUSE_THRESHOLD
+        )
+        at_max = len(cur) >= max_words
+        if is_sent or has_pause or at_max or (is_clause and len(cur) >= 2):
+            chunks.append(cur)
+            cur = []
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# FFmpeg / FFprobe helpers
+# ---------------------------------------------------------------------------
+
+def _run(cmd, check=True):
+    log(f"  $ {' '.join(cmd)}")
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def get_video_info(video_path):
+    """Return (resolution_dict, duration_float) via ffprobe."""
+    cmd = [
+        "ffprobe", "-v", "quiet", "-print_format", "json",
+        "-show_format", "-show_streams", video_path,
+    ]
+    result = _run(cmd)
+    data = json.loads(result.stdout)
+    width, height, duration = 1920, 1080, 0.0
+    for s in data.get("streams", []):
+        if s.get("codec_type") == "video":
+            width = int(s.get("width", width))
+            height = int(s.get("height", height))
+            break
+    duration = float(data.get("format", {}).get("duration", 0.0))
+    return {"width": width, "height": height}, duration
+
+
+def extract_audio(video_path, output_wav):
+    _run([
+        "ffmpeg", "-y", "-i", video_path, "-vn",
+        "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", output_wav,
+    ])
+    return output_wav
+
+
+# ---------------------------------------------------------------------------
+# Transcription
+# ---------------------------------------------------------------------------
+
+def transcribe(video_path, model_name="base", resolution=None, duration=None):
+    """Transcribe video → intermediate caption dict (segments + word timestamps)."""
+    try:
+        import whisper
+    except ImportError:
+        print("Error: openai-whisper not installed. Run: pip install openai-whisper",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if resolution is None or duration is None:
+        res, dur = get_video_info(video_path)
+        resolution = resolution or res
+        duration = duration if duration is not None else dur
+
+    tmp_dir = tempfile.mkdtemp(prefix="captions_")
+    wav_path = os.path.join(tmp_dir, "audio.wav")
+
+    log(f"Extracting audio from {os.path.basename(video_path)}...")
+    extract_audio(video_path, wav_path)
+
+    log(f"Loading Whisper model '{model_name}'...")
+    model = whisper.load_model(model_name)
+
+    log("Transcribing with word timestamps...")
+    result = model.transcribe(wav_path, word_timestamps=True)
+
+    try:
+        os.remove(wav_path)
+        os.rmdir(tmp_dir)
+    except OSError:
+        pass
+
+    segments = []
+    for seg in result.get("segments", []):
+        words = []
+        for w in seg.get("words", []):
+            words.append({
+                "text": w["word"].strip(),
+                "start": round(w["start"], 3),
+                "end": round(w["end"], 3),
+            })
+        if words:
+            segments.append({
+                "start": round(seg["start"], 3),
+                "end": round(seg["end"], 3),
+                "text": " ".join(w["text"] for w in words),
+                "words": words,
+            })
+
+    caption_data = {
+        "video_path": os.path.abspath(video_path),
+        "resolution": resolution,
+        "duration": round(duration, 3),
+        "style": {"preset": "classic"},
+        "segments": segments,
+    }
+
+    log(f"Transcription complete: {len(segments)} segments, {duration:.1f}s")
+    return caption_data
+
+
+# ---------------------------------------------------------------------------
+# ASS generation (no pysubs2 dependency — raw string output)
+# ---------------------------------------------------------------------------
+
+def _ass_timestamp(seconds):
+    """Convert seconds (float) to ASS timestamp 'H:MM:SS.cc'."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = seconds % 60
+    return f"{h}:{m:02d}:{s:05.2f}"
+
+
+def _build_ass_header(style, resolution):
+    """Return the [Script Info] and [V4+ Styles] sections as a string."""
+    w = resolution.get("width", 1920)
+    h = resolution.get("height", 1080)
+    is_portrait = h > w
+    margin_v = 80 if is_portrait else 40
+    margin_h = 60 if is_portrait else 40
+
+    align = ALIGNMENT_MAP.get(style["position"], 2)
+    has_bg = style.get("background_color") is not None
+    shadow = style.get("shadow_depth", 0)
+
+    # In ASS karaoke mode: PrimaryColour is the highlight (sweep destination),
+    # SecondaryColour is the base text (pre-highlight). We swap semantics so
+    # that primary_color = base text and secondary_color = highlight matches
+    # the user-facing mental model ("primary" = what you mostly see).
+    anim = style.get("animation", "karaoke-sweep")
+    if anim in ("karaoke", "karaoke-sweep"):
+        # ASS: Primary = highlight target, Secondary = pre-highlight base
+        pc = hex_to_ass_color(style["secondary_color"])
+        sc = hex_to_ass_color(style["primary_color"])
+    else:
+        pc = hex_to_ass_color(style["primary_color"])
+        sc = hex_to_ass_color(style["secondary_color"])
+
+    oc = hex_to_ass_color(style["outline_color"])
+    # Back color: used for shadow / box. Transparent black by default.
+    bc = hex_to_ass_color("#000000", alpha=128)
+
+    border_style = 1  # outline + shadow
+
+    lines = [
+        "[Script Info]",
+        "Title: Generated by generate-captions skill",
+        "ScriptType: v4.00+",
+        f"PlayResX: {w}",
+        f"PlayResY: {h}",
+        "ScaledBorderAndShadow: yes",
+        "",
+        "[V4+ Styles]",
+        "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "
+        "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, "
+        "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+        "Alignment, MarginL, MarginR, MarginV, Encoding",
+        f"Style: Default,{style['font_family']},{style['font_size']},"
+        f"{pc},{sc},{oc},{bc},"
+        f"-1,0,0,0,100,100,0,0,{border_style},{style['outline_width']},{shadow},"
+        f"{align},{margin_h},{margin_h},{margin_v},1",
+    ]
+
+    # Background box layer: a separate style with BorderStyle=3 (opaque box)
+    if has_bg:
+        bg_color = hex_to_ass_color(style["background_color"], alpha=80)
+        lines.append(
+            f"Style: DefaultBG,{style['font_family']},{style['font_size']},"
+            f"{bg_color},{bg_color},{bg_color},{bg_color},"
+            f"-1,0,0,0,100,100,0,0,3,0,0,"
+            f"{align},{margin_h},{margin_h},{margin_v},1"
+        )
+
+    return "\n".join(lines)
+
+
+def _build_ass_events(style, segments):
+    """Return the [Events] section as a string."""
+    anim = style.get("animation", "karaoke-sweep")
+    wpl = 1 if style.get("single_words") else style.get("words_per_line", 4)
+    has_bg = style.get("background_color") is not None
+
+    lines = [
+        "",
+        "[Events]",
+        "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
+    ]
+
+    for segment in segments:
+        words = segment.get("words", [])
+        if not words:
+            ts = _ass_timestamp(segment["start"])
+            te = _ass_timestamp(segment["end"])
+            text = segment.get("text", "")
+            if has_bg:
+                lines.append(f"Dialogue: 0,{ts},{te},DefaultBG,,0,0,0,,{text}")
+            lines.append(f"Dialogue: 1,{ts},{te},Default,,0,0,0,,{text}")
+            continue
+
+        chunks = smart_chunk_words(words, wpl)
+
+        for chunk in chunks:
+            ts = _ass_timestamp(chunk[0]["start"])
+            te = _ass_timestamp(chunk[-1]["end"])
+
+            # Build plain text (for BG layer) and tagged text (for main layer)
+            plain_parts = []
+            tagged_parts = []
+            for i, word in enumerate(chunk):
+                plain_parts.append(word["text"])
+                if anim in ("karaoke", "karaoke-sweep"):
+                    if i < len(chunk) - 1:
+                        next_start = chunk[i + 1]["start"]
+                    else:
+                        next_start = word["end"]
+                    dur_cs = max(1, int((next_start - word["start"]) * 100))
+                    tag = "kf" if anim == "karaoke-sweep" else "k"
+                    tagged_parts.append(f"{{\\{tag}{dur_cs}}}{word['text']}")
+                else:
+                    tagged_parts.append(word["text"])
+
+                if i < len(chunk) - 1:
+                    plain_parts.append(" ")
+                    tagged_parts.append(" ")
+
+            plain_text = "".join(plain_parts)
+            tagged_text = "".join(tagged_parts)
+
+            if has_bg:
+                lines.append(
+                    f"Dialogue: 0,{ts},{te},DefaultBG,,0,0,0,,{plain_text}"
+                )
+            lines.append(
+                f"Dialogue: 1,{ts},{te},Default,,0,0,0,,{tagged_text}"
+            )
+
+    return "\n".join(lines)
+
+
+def generate_ass(style, caption_data):
+    """Generate a complete ASS subtitle string from style config and caption data."""
+    resolution = caption_data.get("resolution", {"width": 1920, "height": 1080})
+    segments = caption_data.get("segments", [])
+    header = _build_ass_header(style, resolution)
+    events = _build_ass_events(style, segments)
+    return header + "\n" + events + "\n"
+
+
+# ---------------------------------------------------------------------------
+# List styles
+# ---------------------------------------------------------------------------
+
+def print_styles():
+    print("Available style presets:\n")
+    for name, p in PRESETS.items():
+        bg = p["background_color"] or "none"
+        print(f"  {name}")
+        print(f"    Font:         {p['font_family']} {p['font_size']}pt")
+        print(f"    Primary:      {p['primary_color']}  Secondary: {p['secondary_color']}")
+        print(f"    Outline:      {p['outline_color']} ({p['outline_width']}px)  Shadow: {p['shadow_depth']}")
+        print(f"    Background:   {bg}")
+        print(f"    Position:     {p['position']}  Animation: {p['animation']}")
+        print(f"    Words/line:   {p['words_per_line']}  Single: {p['single_words']}")
+        print()
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="caption_video",
+        description="Transcribe video and generate styled ASS subtitles.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+examples:
+  %(prog)s video.mp4 --transcribe-only              Whisper → captions.json
+  %(prog)s video.mp4 --json captions.json --style pop   JSON → styled ASS
+  %(prog)s video.mp4 --json c.json --font-size 72       Override preset font size
+  %(prog)s --list-styles                                 Show all presets
+
+presets: classic, pop, bold, boxed, single
+whisper models: tiny, base, small, medium, large
+""",
+    )
+
+    parser.add_argument("video", nargs="?", help="Input video file")
+    parser.add_argument("--list-styles", action="store_true",
+                        help="List all style presets and exit")
+
+    # Mode flags
+    mode = parser.add_argument_group("mode")
+    mode.add_argument("--transcribe-only", action="store_true",
+                      help="Only transcribe → captions.json (skip ASS)")
+    mode.add_argument("--json", metavar="FILE",
+                      help="Path to existing caption JSON (skip transcription)")
+
+    # Whisper
+    parser.add_argument("--model", default="base",
+                        choices=["tiny", "base", "small", "medium", "large"],
+                        help="Whisper model size (default: base)")
+
+    # Style
+    style_g = parser.add_argument_group("style")
+    style_g.add_argument("--style", "-s", default=None,
+                         choices=list(PRESETS.keys()),
+                         help="Style preset (default: classic)")
+    style_g.add_argument("--font-family", default=None, dest="font_family",
+                         help="Override font family")
+    style_g.add_argument("--font-size", type=int, default=None, dest="font_size",
+                         help="Override font size (pt)")
+    style_g.add_argument("--primary-color", default=None, dest="primary_color",
+                         help="Base text color (#RRGGBB)")
+    style_g.add_argument("--secondary-color", default=None, dest="secondary_color",
+                         help="Highlight/active word color (#RRGGBB)")
+    style_g.add_argument("--outline-color", default=None, dest="outline_color",
+                         help="Outline color (#RRGGBB)")
+    style_g.add_argument("--outline-width", type=int, default=None, dest="outline_width",
+                         help="Outline width (px)")
+    style_g.add_argument("--shadow-depth", type=int, default=None, dest="shadow_depth",
+                         help="Shadow depth (px, 0=none)")
+    style_g.add_argument("--background-color", default=None, dest="background_color",
+                         help="Background box color (#RRGGBB, enables boxed mode)")
+    style_g.add_argument("--position", default=None,
+                         choices=["bottom", "center", "top"],
+                         help="Caption position")
+    style_g.add_argument("--animation", default=None,
+                         choices=["none", "karaoke", "karaoke-sweep"],
+                         help="Animation type")
+    style_g.add_argument("--words-per-line", type=int, default=None, dest="words_per_line",
+                         help="Max words per display chunk")
+    style_g.add_argument("--single-words", action="store_true", default=None,
+                         dest="single_words",
+                         help="Show one word at a time")
+
+    # Output
+    parser.add_argument("--output-dir", metavar="DIR",
+                        help="Output directory (default: same as video)")
+    parser.add_argument("-o", "--output", metavar="FILE",
+                        help="Write result JSON to file instead of stdout")
+    parser.add_argument("-q", "--quiet", action="store_true",
+                        help="Suppress progress messages")
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    global _quiet
+
+    parser = build_parser()
+    args = parser.parse_args()
+    _quiet = args.quiet
+
+    if args.list_styles:
+        print_styles()
+        sys.exit(0)
+
+    if not args.video:
+        parser.error("the following argument is required: video")
+
+    video_abs = os.path.abspath(args.video)
+    video_stem = os.path.splitext(os.path.basename(video_abs))[0]
+    output_dir = args.output_dir or os.path.dirname(video_abs)
+    os.makedirs(output_dir, exist_ok=True)
+
+    transcript_path = os.path.join(output_dir, f"{video_stem}_captions.json")
+    ass_path = os.path.join(output_dir, f"{video_stem}_captions.ass")
+
+    result = {
+        "video": os.path.basename(video_abs),
+        "transcript_file": None,
+        "ass_file": None,
+        "segments_count": 0,
+        "duration": 0.0,
+    }
+
+    # ---- Load or transcribe ----
+    if args.json:
+        log(f"Loading caption JSON: {args.json}")
+        with open(args.json, "r", encoding="utf-8") as f:
+            caption_data = json.load(f)
+        transcript_path = os.path.abspath(args.json)
+    else:
+        if not os.path.isfile(video_abs):
+            parser.error(f"video file not found: {video_abs}")
+
+        log("Getting video info...")
+        resolution, duration = get_video_info(video_abs)
+        caption_data = transcribe(video_abs, model_name=args.model,
+                                  resolution=resolution, duration=duration)
+
+        with open(transcript_path, "w", encoding="utf-8") as f:
+            json.dump(caption_data, f, indent=2, ensure_ascii=False)
+        log(f"Transcript saved: {transcript_path}")
+
+    result["transcript_file"] = os.path.abspath(transcript_path)
+    result["segments_count"] = len(caption_data.get("segments", []))
+    result["duration"] = caption_data.get("duration", 0.0)
+
+    if args.transcribe_only:
+        result_json = json.dumps(result, indent=2, ensure_ascii=False)
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(result_json + "\n")
+            log(f"Result written to: {args.output}")
+        else:
+            print(result_json)
+        return
+
+    # ---- Resolve style and generate ASS ----
+    json_style = caption_data.get("style", {})
+    style = resolve_style(args, json_style)
+
+    log(f"Style: {style['preset']} (font={style['font_family']} {style['font_size']}pt, "
+        f"pos={style['position']}, anim={style['animation']})")
+
+    ass_content = generate_ass(style, caption_data)
+
+    with open(ass_path, "w", encoding="utf-8") as f:
+        f.write(ass_content)
+    log(f"ASS file saved: {ass_path}")
+
+    result["ass_file"] = os.path.abspath(ass_path)
+    result["style"] = style
+
+    # ---- Output result ----
+    result_json = json.dumps(result, indent=2, ensure_ascii=False)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(result_json + "\n")
+        log(f"Result written to: {args.output}")
+    else:
+        print(result_json)
+
+    # Print burn-in hint
+    log("")
+    log("To burn captions into video:")
+    log(f'  ffmpeg -y -i "{video_abs}" -vf "ass={ass_path}" -c:a copy "{os.path.join(output_dir, video_stem + "_captioned.mp4")}"')
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/generate-captions/scripts/generate_preview.py
+++ b/skills/generate-captions/scripts/generate_preview.py
@@ -1,0 +1,873 @@
+#!/usr/bin/env python3
+"""Standalone HTML preview for caption editing.
+
+Generates a self-contained HTML file with:
+- Video playback with CSS-based caption overlay (word-by-word highlighting)
+- Style controls panel (position, font size, colors, animation, etc.)
+- Caption text editing panel (editable word inputs, click-to-seek timestamps)
+- Export JSON and Reset buttons
+
+The preview uses CSS custom properties for live style updates and
+requestAnimationFrame for smooth caption sync during playback.
+"""
+
+import json
+import os
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _escape_js_string(text):
+    """Escape a string for embedding inside a JS string literal."""
+    return (
+        text.replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("<", "\\x3c")
+        .replace(">", "\\x3e")
+    )
+
+
+def _escape_html(text):
+    """Escape a string for embedding in HTML attribute or content."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main generator
+# ---------------------------------------------------------------------------
+
+def generate_preview_html(caption_data, video_relative_path):
+    """Generate a CSS-based caption preview HTML string.
+
+    Parameters
+    ----------
+    caption_data : dict
+        The intermediate caption JSON data with keys:
+        - style: {font_family, font_size, primary_color, secondary_color,
+                  outline_color, outline_width, shadow_depth, background_color,
+                  position, animation, words_per_line}
+        - segments: [{start, end, text, words: [{text, start, end}]}]
+        - resolution: {width, height}
+    video_relative_path : str
+        Filename (not a path traversal) of the video file, expected to be
+        in the same directory as the output HTML.
+
+    Returns
+    -------
+    str
+        Complete HTML document as a string.
+    """
+    # Extract only the filename to prevent path traversal
+    video_filename = os.path.basename(video_relative_path)
+
+    style = caption_data.get("style", {})
+    segments = caption_data.get("segments", [])
+    resolution = caption_data.get("resolution", {"width": 1920, "height": 1080})
+
+    font_family = style.get("font_family", "Arial Black")
+    font_size = style.get("font_size", 48)
+    primary_color = style.get("primary_color", "#FFFFFF")
+    secondary_color = style.get("secondary_color", "#00FFB2")
+    outline_color = style.get("outline_color", "#000000")
+    outline_width = style.get("outline_width", 3)
+    shadow_depth = style.get("shadow_depth", 0)
+    background_color = style.get("background_color", None) or ""
+    position = style.get("position", "center")
+    animation = style.get("animation", "karaoke-sweep")
+    words_per_line = style.get("words_per_line", 4)
+
+    # Serialize data for JS embedding
+    segments_json = _escape_js_string(json.dumps(segments))
+    caption_data_json = _escape_js_string(json.dumps(caption_data))
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Caption Preview</title>
+<style>
+:root {{
+    --caption-primary: {primary_color};
+    --caption-secondary: {secondary_color};
+    --caption-outline: {outline_color};
+    --caption-outline-w: {outline_width}px;
+    --caption-shadow-depth: {shadow_depth}px;
+    --caption-bg: {background_color if background_color else 'transparent'};
+}}
+
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+
+body {{
+    background: #111;
+    color: #e0e0e0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+    min-height: 100vh;
+}}
+
+h1 {{
+    font-size: 1.4rem;
+    margin-bottom: 16px;
+    color: #ccc;
+}}
+h1 span {{
+    font-size: 0.75rem;
+    color: #666;
+    font-weight: normal;
+}}
+
+/* ---- Video wrapper + caption overlay ---- */
+.video-container {{
+    position: relative;
+    width: 100%;
+    max-width: 900px;
+    background: #000;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 20px;
+}}
+video {{
+    width: 100%;
+    display: block;
+}}
+.caption-overlay {{
+    position: absolute;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 10;
+    padding: 0 40px;
+}}
+.caption-overlay.pos-top {{ top: 40px; align-items: flex-start; }}
+.caption-overlay.pos-center {{ top: 0; bottom: 0; align-items: center; }}
+.caption-overlay.pos-bottom {{ bottom: 60px; align-items: flex-end; }}
+
+.caption-line {{
+    font-family: var(--caption-font-family, "Arial Black"), "Impact", sans-serif;
+    font-size: var(--caption-font-size, {font_size}px);
+    font-weight: 900;
+    text-align: center;
+    line-height: 1.3;
+    white-space: pre-wrap;
+    color: var(--caption-secondary);
+    text-shadow:
+        calc(var(--caption-outline-w) *  1) calc(var(--caption-outline-w) *  0) 0 var(--caption-outline),
+        calc(var(--caption-outline-w) * -1) calc(var(--caption-outline-w) *  0) 0 var(--caption-outline),
+        calc(var(--caption-outline-w) *  0) calc(var(--caption-outline-w) *  1) 0 var(--caption-outline),
+        calc(var(--caption-outline-w) *  0) calc(var(--caption-outline-w) * -1) 0 var(--caption-outline),
+        calc(var(--caption-outline-w) *  0.71) calc(var(--caption-outline-w) *  0.71) 0 var(--caption-outline),
+        calc(var(--caption-outline-w) * -0.71) calc(var(--caption-outline-w) *  0.71) 0 var(--caption-outline),
+        calc(var(--caption-outline-w) *  0.71) calc(var(--caption-outline-w) * -0.71) 0 var(--caption-outline),
+        calc(var(--caption-outline-w) * -0.71) calc(var(--caption-outline-w) * -0.71) 0 var(--caption-outline),
+        var(--caption-shadow-depth) var(--caption-shadow-depth) calc(var(--caption-shadow-depth) * 0.5) rgba(0,0,0,0.6);
+    background: var(--caption-bg);
+    padding: 4px 12px;
+    border-radius: 4px;
+}}
+.caption-word {{
+    display: inline;
+    transition: color 0.05s ease;
+}}
+.caption-word.active {{
+    color: var(--caption-primary);
+}}
+
+/* ---- Panels ---- */
+.panels {{
+    width: 100%;
+    max-width: 900px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}}
+.panel {{
+    background: #1e1e1e;
+    border: 1px solid #2a2a2a;
+    border-radius: 8px;
+    padding: 20px;
+}}
+.panel h2 {{
+    font-size: 1rem;
+    margin-bottom: 14px;
+    color: #999;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}}
+
+/* ---- Style controls ---- */
+.style-grid {{
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 14px;
+}}
+.style-grid label {{
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8rem;
+    color: #888;
+}}
+.style-grid select,
+.style-grid input[type="number"] {{
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #e0e0e0;
+    padding: 6px 8px;
+    border-radius: 4px;
+    font-size: 0.85rem;
+}}
+.style-grid input[type="color"] {{
+    width: 100%;
+    height: 30px;
+    border: 1px solid #3a3a3a;
+    border-radius: 4px;
+    padding: 0;
+    cursor: pointer;
+    background: transparent;
+}}
+.style-grid input[type="range"] {{
+    width: 100%;
+    accent-color: var(--caption-primary);
+}}
+.range-val {{
+    font-size: 0.75rem;
+    color: #666;
+    text-align: right;
+}}
+
+/* ---- Caption editing ---- */
+.segment-list {{
+    max-height: 400px;
+    overflow-y: auto;
+    padding-right: 4px;
+}}
+.segment-row {{
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 10px;
+    gap: 12px;
+}}
+.segment-time {{
+    font-size: 0.78rem;
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+    color: #666;
+    min-width: 120px;
+    padding-top: 6px;
+    cursor: pointer;
+    white-space: nowrap;
+    user-select: none;
+}}
+.segment-time:hover {{
+    color: var(--caption-primary);
+}}
+.segment-words {{
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    flex: 1;
+}}
+.segment-words input {{
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #e0e0e0;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.88rem;
+    min-width: 50px;
+}}
+.segment-words input:focus {{
+    outline: none;
+    border-color: var(--caption-primary);
+    box-shadow: 0 0 0 1px var(--caption-primary);
+}}
+
+/* ---- Action buttons ---- */
+.actions {{
+    display: flex;
+    gap: 10px;
+    margin-top: 8px;
+}}
+.btn {{
+    border: none;
+    padding: 10px 24px;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}}
+.btn:hover {{ opacity: 0.85; }}
+.btn-primary {{
+    background: var(--caption-primary);
+    color: #000;
+}}
+.btn-secondary {{
+    background: #333;
+    color: #e0e0e0;
+}}
+
+/* Scrollbar styling */
+.segment-list::-webkit-scrollbar {{ width: 6px; }}
+.segment-list::-webkit-scrollbar-track {{ background: transparent; }}
+.segment-list::-webkit-scrollbar-thumb {{
+    background: #444;
+    border-radius: 3px;
+}}
+</style>
+</head>
+<body>
+
+<h1>Caption Preview <span>(CSS overlay &mdash; edit &amp; export)</span></h1>
+
+<div class="video-container">
+    <video id="video" controls preload="metadata">
+        <source src="{_escape_html(video_filename)}" type="video/mp4">
+    </video>
+    <div id="caption-overlay" class="caption-overlay pos-{_escape_html(position)}">
+        <div id="caption-line" class="caption-line"></div>
+    </div>
+</div>
+
+<div class="panels">
+    <!-- Style Controls -->
+    <div class="panel">
+        <h2>Style Controls</h2>
+        <div class="style-grid">
+            <label>Position
+                <select id="ctl-position">
+                    <option value="top"{"selected" if position == "top" else ""}>Top</option>
+                    <option value="center"{"selected" if position == "center" else ""}>Center</option>
+                    <option value="bottom"{"selected" if position == "bottom" else ""}>Bottom</option>
+                </select>
+            </label>
+            <label>Font Size
+                <input id="ctl-fontsize" type="range" min="16" max="120" value="{font_size}">
+                <span id="ctl-fontsize-val" class="range-val">{font_size}px</span>
+            </label>
+            <label>Highlight Color
+                <input id="ctl-primary" type="color" value="{primary_color}">
+            </label>
+            <label>Text Color
+                <input id="ctl-secondary" type="color" value="{secondary_color}">
+            </label>
+            <label>Outline Color
+                <input id="ctl-outline" type="color" value="{outline_color}">
+            </label>
+            <label>Outline Width
+                <input id="ctl-outline-width" type="range" min="0" max="8" value="{outline_width}">
+                <span id="ctl-outline-width-val" class="range-val">{outline_width}px</span>
+            </label>
+            <label>Shadow Depth
+                <input id="ctl-shadow" type="range" min="0" max="10" value="{shadow_depth}">
+                <span id="ctl-shadow-val" class="range-val">{shadow_depth}px</span>
+            </label>
+            <label>Background
+                <input id="ctl-bg" type="color" value="{background_color if background_color else '#000000'}">
+            </label>
+            <label>BG Enabled
+                <select id="ctl-bg-on">
+                    <option value="false"{"" if background_color else " selected"}>Off</option>
+                    <option value="true"{" selected" if background_color else ""}>On</option>
+                </select>
+            </label>
+            <label>Animation
+                <select id="ctl-animation">
+                    <option value="none"{"selected" if animation == "none" else ""}>None</option>
+                    <option value="karaoke"{"selected" if animation == "karaoke" else ""}>Karaoke</option>
+                    <option value="karaoke-sweep"{"selected" if animation == "karaoke-sweep" else ""}>Karaoke Sweep</option>
+                </select>
+            </label>
+            <label>Words / Line
+                <input id="ctl-wpl" type="number" min="1" max="20" value="{words_per_line}">
+            </label>
+            <label>Single Word
+                <select id="ctl-single">
+                    <option value="false" selected>Off</option>
+                    <option value="true">On</option>
+                </select>
+            </label>
+        </div>
+    </div>
+
+    <!-- Caption Text Editing -->
+    <div class="panel">
+        <h2>Caption Text</h2>
+        <div id="segment-list" class="segment-list"></div>
+        <div class="actions">
+            <button class="btn btn-primary" id="btn-export">Export JSON</button>
+            <button class="btn btn-secondary" id="btn-reset">Reset</button>
+        </div>
+    </div>
+</div>
+
+<script>
+(function() {{
+    "use strict";
+
+    // ---- DOM refs ----
+    var video = document.getElementById("video");
+    var captionOverlay = document.getElementById("caption-overlay");
+    var captionLine = document.getElementById("caption-line");
+    var segmentList = document.getElementById("segment-list");
+    var root = document.documentElement;
+
+    // ---- Data ----
+    var originalSegments = JSON.parse('{segments_json}');
+    var segments = JSON.parse(JSON.stringify(originalSegments));
+    var captionData = JSON.parse('{caption_data_json}');
+    var resolution = captionData.resolution || {{ width: 1920, height: 1080 }};
+
+    // ---- Style state ----
+    var styleState = {{
+        fontFamily: '{_escape_js_string(font_family)}',
+        position: '{_escape_js_string(position)}',
+        fontSize: {font_size},
+        primaryColor: '{_escape_js_string(primary_color)}',
+        secondaryColor: '{_escape_js_string(secondary_color)}',
+        outlineColor: '{_escape_js_string(outline_color)}',
+        outlineWidth: {outline_width},
+        shadowDepth: {shadow_depth},
+        backgroundColor: '{_escape_js_string(background_color)}',
+        bgEnabled: {'true' if background_color else 'false'},
+        animation: '{_escape_js_string(animation)}',
+        wordsPerLine: {words_per_line},
+        singleWord: false
+    }};
+
+    // ---- Smart chunking (mirrors Python logic) ----
+    var SENTENCE_ENDERS = [".", "!", "?"];
+    var CLAUSE_BREAKS = [",", ";", ":", "\\u2014", "\\u2013", "-"];
+    var PAUSE_THRESHOLD = 0.5;
+
+    function smartChunk(words, maxWpl) {{
+        if (maxWpl <= 1) {{
+            return words.map(function(w) {{ return [w]; }});
+        }}
+        var chunks = [];
+        var cur = [];
+        for (var i = 0; i < words.length; i++) {{
+            cur.push(words[i]);
+            var txt = (words[i].text || "").replace(/\\s+$/, "");
+            var isSentEnd = SENTENCE_ENDERS.some(function(p) {{ return txt.endsWith(p); }});
+            var isClause = CLAUSE_BREAKS.some(function(p) {{ return txt.endsWith(p); }});
+            var hasPause = false;
+            if (i < words.length - 1) {{
+                hasPause = (words[i + 1].start - words[i].end) >= PAUSE_THRESHOLD;
+            }}
+            var atMax = cur.length >= maxWpl;
+            if (isSentEnd || hasPause || atMax || (isClause && cur.length >= 2)) {{
+                chunks.push(cur);
+                cur = [];
+            }}
+        }}
+        if (cur.length > 0) {{ chunks.push(cur); }}
+        return chunks;
+    }}
+
+    // ---- Build all chunks from all segments ----
+    var allChunks = [];
+
+    function rebuildChunks() {{
+        allChunks = [];
+        var wpl = styleState.singleWord ? 1 : styleState.wordsPerLine;
+        for (var si = 0; si < segments.length; si++) {{
+            var seg = segments[si];
+            var words = seg.words || [];
+            if (words.length === 0) continue;
+            var chunks = smartChunk(words, wpl);
+            for (var ci = 0; ci < chunks.length; ci++) {{
+                var chunk = chunks[ci];
+                allChunks.push({{
+                    start: chunk[0].start,
+                    end: chunk[chunk.length - 1].end,
+                    words: chunk
+                }});
+            }}
+        }}
+    }}
+
+    rebuildChunks();
+
+    // ---- CSS custom property updates ----
+    function applyCSSProperties() {{
+        root.style.setProperty("--caption-primary", styleState.primaryColor);
+        root.style.setProperty("--caption-secondary", styleState.secondaryColor);
+        root.style.setProperty("--caption-outline", styleState.outlineColor);
+        root.style.setProperty("--caption-outline-w", styleState.outlineWidth + "px");
+        root.style.setProperty("--caption-shadow-depth", styleState.shadowDepth + "px");
+        root.style.setProperty("--caption-bg", styleState.bgEnabled ? styleState.backgroundColor : "transparent");
+        root.style.setProperty("--caption-font-size", styleState.fontSize + "px");
+        root.style.setProperty("--caption-font-family", '"' + styleState.fontFamily + '"');
+    }}
+
+    function applyPosition() {{
+        captionOverlay.className = "caption-overlay pos-" + styleState.position;
+    }}
+
+    // ---- Caption rendering with requestAnimationFrame ----
+    var lastRenderedChunkIndex = -1;
+    var lastRenderedActiveWord = -1;
+    var currentChunkWordSpans = [];
+
+    function escapeHTMLText(str) {{
+        var div = document.createElement("div");
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }}
+
+    function renderCaption(t) {{
+        // Find the active chunk
+        var activeChunk = null;
+        var activeIdx = -1;
+        for (var i = 0; i < allChunks.length; i++) {{
+            if (t >= allChunks[i].start && t < allChunks[i].end) {{
+                activeChunk = allChunks[i];
+                activeIdx = i;
+                break;
+            }}
+        }}
+
+        if (activeChunk === null) {{
+            // No active chunk at this time
+            if (lastRenderedChunkIndex !== -1) {{
+                captionLine.innerHTML = "";
+                currentChunkWordSpans = [];
+                lastRenderedChunkIndex = -1;
+                lastRenderedActiveWord = -1;
+            }}
+            return;
+        }}
+
+        // Rebuild DOM if the chunk changed
+        if (activeIdx !== lastRenderedChunkIndex) {{
+            captionLine.innerHTML = "";
+            currentChunkWordSpans = [];
+            var words = activeChunk.words;
+            for (var wi = 0; wi < words.length; wi++) {{
+                if (wi > 0) {{
+                    var space = document.createTextNode(" ");
+                    captionLine.appendChild(space);
+                }}
+                var span = document.createElement("span");
+                span.className = "caption-word";
+                span.textContent = words[wi].text;
+                captionLine.appendChild(span);
+                currentChunkWordSpans.push(span);
+            }}
+            lastRenderedChunkIndex = activeIdx;
+            lastRenderedActiveWord = -1;
+        }}
+
+        // Highlight the currently spoken word based on animation mode
+        if (styleState.animation === "none") {{
+            // No animation: all words shown in secondary color (default), no highlight
+            if (lastRenderedActiveWord !== -2) {{
+                for (var j = 0; j < currentChunkWordSpans.length; j++) {{
+                    currentChunkWordSpans[j].classList.remove("active");
+                }}
+                lastRenderedActiveWord = -2;
+            }}
+        }} else {{
+            // Karaoke / karaoke-sweep: highlight ONLY the currently-spoken word
+            var activeWordIdx = -1;
+            var chunkWords = activeChunk.words;
+            for (var k = 0; k < chunkWords.length; k++) {{
+                if (t >= chunkWords[k].start && t < chunkWords[k].end) {{
+                    activeWordIdx = k;
+                    break;
+                }}
+            }}
+
+            if (activeWordIdx !== lastRenderedActiveWord) {{
+                for (var m = 0; m < currentChunkWordSpans.length; m++) {{
+                    if (m === activeWordIdx) {{
+                        currentChunkWordSpans[m].classList.add("active");
+                    }} else {{
+                        currentChunkWordSpans[m].classList.remove("active");
+                    }}
+                }}
+                lastRenderedActiveWord = activeWordIdx;
+            }}
+        }}
+    }}
+
+    // ---- Animation loop ----
+    var rafId = null;
+
+    function tick() {{
+        if (!video.paused && !video.ended) {{
+            renderCaption(video.currentTime);
+        }}
+        rafId = requestAnimationFrame(tick);
+    }}
+
+    // Start the loop immediately; it checks paused state internally
+    rafId = requestAnimationFrame(tick);
+
+    // Also render on seek / play / pause to keep overlay in sync
+    video.addEventListener("seeked", function() {{ renderCaption(video.currentTime); }});
+    video.addEventListener("play", function() {{ renderCaption(video.currentTime); }});
+    video.addEventListener("pause", function() {{ renderCaption(video.currentTime); }});
+
+    // ---- Style controls wiring ----
+    function onStyleChange(needsRechunk) {{
+        applyCSSProperties();
+        if (needsRechunk) {{
+            rebuildChunks();
+            // Force re-render by resetting tracking
+            lastRenderedChunkIndex = -1;
+            lastRenderedActiveWord = -1;
+            renderCaption(video.currentTime);
+        }}
+    }}
+
+    function wire(id, evt, fn) {{
+        document.getElementById(id).addEventListener(evt, fn);
+    }}
+
+    wire("ctl-position", "change", function(e) {{
+        styleState.position = e.target.value;
+        applyPosition();
+    }});
+
+    wire("ctl-fontsize", "input", function(e) {{
+        styleState.fontSize = parseInt(e.target.value, 10);
+        document.getElementById("ctl-fontsize-val").textContent = e.target.value + "px";
+        onStyleChange(false);
+    }});
+
+    wire("ctl-primary", "input", function(e) {{
+        styleState.primaryColor = e.target.value;
+        onStyleChange(false);
+    }});
+
+    wire("ctl-secondary", "input", function(e) {{
+        styleState.secondaryColor = e.target.value;
+        onStyleChange(false);
+    }});
+
+    wire("ctl-outline", "input", function(e) {{
+        styleState.outlineColor = e.target.value;
+        onStyleChange(false);
+    }});
+
+    wire("ctl-outline-width", "input", function(e) {{
+        styleState.outlineWidth = parseInt(e.target.value, 10);
+        document.getElementById("ctl-outline-width-val").textContent = e.target.value + "px";
+        onStyleChange(false);
+    }});
+
+    wire("ctl-shadow", "input", function(e) {{
+        styleState.shadowDepth = parseInt(e.target.value, 10);
+        document.getElementById("ctl-shadow-val").textContent = e.target.value + "px";
+        onStyleChange(false);
+    }});
+
+    wire("ctl-bg", "input", function(e) {{
+        styleState.backgroundColor = e.target.value;
+        onStyleChange(false);
+    }});
+
+    wire("ctl-bg-on", "change", function(e) {{
+        styleState.bgEnabled = e.target.value === "true";
+        onStyleChange(false);
+    }});
+
+    wire("ctl-animation", "change", function(e) {{
+        styleState.animation = e.target.value;
+        // Force re-render to update highlight state
+        lastRenderedActiveWord = -1;
+        renderCaption(video.currentTime);
+    }});
+
+    wire("ctl-wpl", "change", function(e) {{
+        styleState.wordsPerLine = parseInt(e.target.value, 10);
+        onStyleChange(true);
+    }});
+
+    wire("ctl-single", "change", function(e) {{
+        styleState.singleWord = e.target.value === "true";
+        onStyleChange(true);
+    }});
+
+    // ---- Caption text editing panel ----
+    function formatTimestamp(seconds) {{
+        var m = Math.floor(seconds / 60);
+        var s = seconds % 60;
+        var sStr = s.toFixed(2);
+        if (s < 10) {{ sStr = "0" + sStr; }}
+        return m + ":" + sStr;
+    }}
+
+    function buildEditPanel() {{
+        segmentList.innerHTML = "";
+        for (var si = 0; si < segments.length; si++) {{
+            (function(segIdx) {{
+                var seg = segments[segIdx];
+                var row = document.createElement("div");
+                row.className = "segment-row";
+
+                // Timestamp label (click to seek)
+                var timeLabel = document.createElement("div");
+                timeLabel.className = "segment-time";
+                timeLabel.textContent = formatTimestamp(seg.start) + " \\u2013 " + formatTimestamp(seg.end);
+                timeLabel.addEventListener("click", function() {{
+                    video.currentTime = seg.start;
+                    video.play();
+                }});
+                row.appendChild(timeLabel);
+
+                // Word input fields
+                var wordsDiv = document.createElement("div");
+                wordsDiv.className = "segment-words";
+                var words = seg.words || [];
+                for (var wi = 0; wi < words.length; wi++) {{
+                    (function(wordIdx) {{
+                        var w = words[wordIdx];
+                        var input = document.createElement("input");
+                        input.type = "text";
+                        input.value = w.text;
+                        input.style.width = Math.max(50, w.text.length * 10 + 20) + "px";
+                        input.addEventListener("input", function(e) {{
+                            segments[segIdx].words[wordIdx].text = e.target.value;
+                            // Rebuild full segment text
+                            segments[segIdx].text = segments[segIdx].words.map(
+                                function(ww) {{ return ww.text; }}
+                            ).join(" ");
+                            e.target.style.width = Math.max(50, e.target.value.length * 10 + 20) + "px";
+                            // Rebuild chunks and re-render
+                            rebuildChunks();
+                            lastRenderedChunkIndex = -1;
+                            lastRenderedActiveWord = -1;
+                            renderCaption(video.currentTime);
+                        }});
+                        wordsDiv.appendChild(input);
+                    }})(wi);
+                }}
+                row.appendChild(wordsDiv);
+                segmentList.appendChild(row);
+            }})(si);
+        }}
+    }}
+
+    // ---- Export JSON ----
+    document.getElementById("btn-export").addEventListener("click", function() {{
+        var data = JSON.parse(JSON.stringify(captionData));
+        data.segments = JSON.parse(JSON.stringify(segments));
+        data.style = data.style || {{}};
+        data.style.font_family = styleState.fontFamily;
+        data.style.font_size = styleState.fontSize;
+        data.style.primary_color = styleState.primaryColor;
+        data.style.secondary_color = styleState.secondaryColor;
+        data.style.outline_color = styleState.outlineColor;
+        data.style.outline_width = styleState.outlineWidth;
+        data.style.shadow_depth = styleState.shadowDepth;
+        data.style.background_color = styleState.bgEnabled ? styleState.backgroundColor : null;
+        data.style.position = styleState.position;
+        data.style.animation = styleState.animation;
+        data.style.words_per_line = styleState.wordsPerLine;
+        data.style.single_words = styleState.singleWord;
+
+        var blob = new Blob([JSON.stringify(data, null, 2)], {{ type: "application/json" }});
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement("a");
+        a.href = url;
+        a.download = "captions_edited.json";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }});
+
+    // ---- Reset ----
+    document.getElementById("btn-reset").addEventListener("click", function() {{
+        segments = JSON.parse(JSON.stringify(originalSegments));
+        rebuildChunks();
+        buildEditPanel();
+        lastRenderedChunkIndex = -1;
+        lastRenderedActiveWord = -1;
+        renderCaption(video.currentTime);
+    }});
+
+    // ---- Init ----
+    applyCSSProperties();
+    applyPosition();
+    buildEditPanel();
+    renderCaption(0);
+}})();
+</script>
+</body>
+</html>"""
+
+    return html
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (standalone usage)
+# ---------------------------------------------------------------------------
+
+def main():
+    """Generate an HTML preview from a caption JSON file."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate standalone caption preview HTML from caption JSON.",
+    )
+    parser.add_argument("caption_json", help="Path to caption JSON file")
+    parser.add_argument(
+        "--video",
+        help="Path to video file (default: uses video_path from caption JSON)",
+    )
+    parser.add_argument(
+        "-o", "--output",
+        help="Output HTML file path (default: preview.html in same dir as caption JSON)",
+    )
+    args = parser.parse_args()
+
+    with open(args.caption_json, "r", encoding="utf-8") as f:
+        caption_data = json.load(f)
+
+    video_path = args.video or caption_data.get("video_path", "video.mp4")
+
+    # Compute output path
+    if args.output:
+        output_path = args.output
+    else:
+        output_dir = os.path.dirname(os.path.abspath(args.caption_json))
+        output_path = os.path.join(output_dir, "preview.html")
+
+    # Use just the filename -- the video should be in the same directory
+    video_filename = os.path.basename(video_path)
+
+    html = generate_preview_html(caption_data, video_filename)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    print(f"Preview saved to: {output_path}", file=sys.stderr)
+    print(
+        f"Ensure '{video_filename}' is in the same directory as '{output_path}'.",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Rewrite caption_video.py** — two clean modes: `--transcribe-only` (video → JSON) and `--json` + style (JSON → ASS). Absorbs generate_ass.py, drops pysubs2 dependency, generates ASS as raw strings.
- **5 new presets**: `classic`, `pop`, `bold`, `boxed`, `single` — with full CLI override flags for font, colors, outline, shadow, background, position, animation, words-per-line
- **Two-layer ASS** for background boxes (`DefaultBG` + `Default` styles), aspect-ratio-aware margins for portrait video
- **Preview cleanup** — remove unused JASSUB/ass_content params, add shadow depth and background box controls to HTML style panel
- **Delete obsolete files**: `generate_ass.py`, `setup.py`, `setup-guide.md`, `output-format.md`

## Workflow

```bash
# Transcribe
python3 caption_video.py video.mp4 --transcribe-only

# Style + ASS
python3 caption_video.py video.mp4 --json captions.json --style pop
python3 caption_video.py video.mp4 --json captions.json --style pop --font-size 72 --primary-color "#FF0000"

# Preview
python3 generate_preview.py captions.json --video video.mp4

# Burn-in (just ffmpeg)
ffmpeg -y -i video.mp4 -vf "ass=captions.ass" -c:a copy captioned.mp4
```

## Test plan

- [ ] `--transcribe-only` → verify JSON with segments/words/timestamps
- [ ] `--json + --style pop` → verify ASS with correct colors/karaoke tags
- [ ] CLI overrides (`--font-size 72 --primary-color "#FF0000"`) override preset
- [ ] `--style boxed` → verify two-layer ASS (DefaultBG + Default)
- [ ] `--style single` → one word per dialogue event
- [ ] `--background-color "#000000"` on classic → ad-hoc boxed mode
- [ ] Preview generation → HTML opens, captions sync, shadow/bg controls work
- [ ] Export JSON from preview → re-import produces updated ASS
- [ ] `ffmpeg -vf "ass=captions.ass"` → burn-in renders correctly
- [ ] Portrait video → larger vertical margins

🤖 Generated with [Claude Code](https://claude.com/claude-code)