### PR TITLE
feat: migrate skills to v3 API endpoints (AIR-130)

### DIFF
--- a/skills/avatar-video/SKILL.md
+++ b/skills/avatar-video/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: avatar-video
 description: |
-  Create AI avatar videos with precise control over avatars, voices, scripts, scenes, and backgrounds using HeyGen's v2 API. Use when: (1) Choosing a specific avatar and voice for a video, (2) Writing exact scripts for an avatar to speak, (3) Building multi-scene videos with different backgrounds per scene, (4) Creating transparent WebM videos for compositing, (5) Using talking photos as video presenters, (6) Integrating HeyGen avatars with Remotion, (7) Batch video generation with exact specs, (8) Brand-consistent production videos with precise control.
-homepage: https://docs.heygen.com/reference/create-a-video
+  Create AI avatar videos with precise control over avatars, voices, scripts, and backgrounds using HeyGen's v3 API (POST /v3/videos). Two modes: type="avatar" with avatar_id, or type="image" with an image AssetInput (Avatar IV). Use when: (1) Choosing a specific avatar and voice for a video, (2) Writing exact scripts for an avatar to speak, (3) Animating a photo into a speaking video (type="image"), (4) Transparent background videos with remove_background, (5) Integrating HeyGen avatars with Remotion, (6) Batch video generation with exact specs, (7) Brand-consistent production videos with precise control.
+homepage: https://docs.heygen.com/reference/create-an-avatar-video
 allowed-tools: mcp__heygen__*
 metadata:
   openclaw:
@@ -14,14 +14,16 @@ metadata:
 
 # Avatar Video
 
-Create AI avatar videos with full control over avatars, voices, scripts, scenes, and backgrounds. Build single or multi-scene videos with exact configuration using HeyGen's `/v2/video/generate` API.
+Create AI avatar videos with full control over avatars, voices, scripts, and backgrounds using `POST /v3/videos`. Two creation modes via discriminated union on `type`:
+- `"type": "avatar"` + `avatar_id` — use a HeyGen avatar from the library
+- `"type": "image"` + `image` (AssetInput) — animate any photo via Avatar IV
 
 ## Authentication
 
 All requests require the `X-Api-Key` header. Set the `HEYGEN_API_KEY` environment variable.
 
 ```bash
-curl -X GET "https://api.heygen.com/v2/avatars" \
+curl -X GET "https://api.heygen.com/v3/avatars" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
@@ -31,85 +33,53 @@ If HeyGen MCP tools are available (`mcp__heygen__*`), **prefer them** over direc
 
 | Task | MCP Tool | Fallback (Direct API) |
 |------|----------|----------------------|
-| Check video status / get URL | `mcp__heygen__get_video` | `GET /v2/videos/{video_id}` |
-| List account videos | `mcp__heygen__list_videos` | `GET /v2/videos` |
-| Delete a video | `mcp__heygen__delete_video` | `DELETE /v2/videos/{video_id}` |
+| Check video status / get URL | `mcp__heygen__get_video` | `GET /v3/videos/{video_id}` |
+| List account videos | `mcp__heygen__list_videos` | `GET /v3/videos` |
+| Delete a video | `mcp__heygen__delete_video` | `DELETE /v3/videos/{video_id}` |
 
-Video generation (`POST /v2/video/generate`) and avatar/voice listing are done via direct API calls — see reference files below.
+Video generation (`POST /v3/videos`) and avatar/voice listing are done via direct API calls — see reference files below.
 
 ## Default Workflow
 
-1. **List avatars** — `GET /v2/avatars` → pick an avatar, preview it, note `avatar_id` and `default_voice_id`. See [avatars.md](references/avatars.md)
-2. **List voices** (if needed) — `GET /v2/voices` → pick a voice matching the avatar's gender/language. See [voices.md](references/voices.md)
+1. **List avatar looks** — `GET /v3/avatars/looks` → pick a look, note its `id` (this is the `avatar_id`) and `default_voice_id`. See [avatars.md](references/avatars.md)
+2. **List voices** (if needed) — `GET /v3/voices` → pick a voice matching the avatar's gender/language. See [voices.md](references/voices.md)
 3. **Write the script** — Structure scenes with one concept each. See [scripts.md](references/scripts.md)
-4. **Generate the video** — `POST /v2/video/generate` with avatar, voice, script, and background per scene. See [video-generation.md](references/video-generation.md)
-5. **Poll for completion** — `GET /v2/videos/{video_id}` until status is `completed`. See [video-status.md](references/video-status.md)
+4. **Generate the video** — `POST /v3/videos` with `avatar_id`, `voice_id`, `script`, and optional `background` per scene. See [video-generation.md](references/video-generation.md)
+5. **Poll for completion** — `GET /v3/videos/{video_id}` until status is `completed`. See [video-status.md](references/video-status.md)
 
-## Quick Reference
+## Routing: This Skill vs Create Video
 
-| Task | Read |
-|------|------|
-| List and preview avatars | [avatars.md](references/avatars.md) |
-| List and select voices | [voices.md](references/voices.md) |
-| Write and structure scripts | [scripts.md](references/scripts.md) |
-| Generate video (single or multi-scene) | [video-generation.md](references/video-generation.md) |
-| Add custom backgrounds | [backgrounds.md](references/backgrounds.md) |
-| Add captions / subtitles | [captions.md](references/captions.md) |
-| Add text overlays | [text-overlays.md](references/text-overlays.md) |
-| Create transparent WebM video | [video-generation.md](references/video-generation.md) (WebM section) |
-| Use templates | [templates.md](references/templates.md) |
-| Create avatar from photo | [photo-avatars.md](references/photo-avatars.md) |
-| Check video status / download | [video-status.md](references/video-status.md) |
-| Upload assets (images, audio) | [assets.md](references/assets.md) |
-| Use with Remotion | [remotion-integration.md](references/remotion-integration.md) |
-| Set up webhooks | [webhooks.md](references/webhooks.md) |
-
-## When to Use This Skill vs Create Video
-
-This skill is for **precise control** — you choose the avatar, write the exact script, configure each scene.
-
-If the user just wants to **describe a video idea** and let AI handle the rest (script, avatar, visuals), use the **create-video** skill instead.
-
-| User Says | Create Video Skill | This Skill |
-|-----------|:------------------:|:----------:|
-| "Make me a video about X" | ✓ | |
-| "Create a product demo" | ✓ | |
-| "I want avatar Y to say exactly Z" | | ✓ |
-| "Multi-scene video with different backgrounds" | | ✓ |
-| "Transparent WebM for compositing" | | ✓ |
-| "Use this specific voice for my script" | | ✓ |
-| "Batch generate videos with exact specs" | | ✓ |
+**This skill** = precise control (specific avatar, exact script, custom background).
+**create-video** = prompt-based ("make me a video about X", AI handles the rest).
 
 ## Reference Files
 
-### Core Video Creation
-- [references/avatars.md](references/avatars.md) - Listing avatars, styles, avatar_id selection
-- [references/voices.md](references/voices.md) - Listing voices, locales, speed/pitch
-- [references/scripts.md](references/scripts.md) - Writing scripts, pauses, pacing
-- [references/video-generation.md](references/video-generation.md) - POST /v2/video/generate and multi-scene videos
+Read these as needed — they contain endpoint details, request/response schemas, and code examples (curl, TypeScript, Python).
 
-### Video Customization
-- [references/backgrounds.md](references/backgrounds.md) - Solid colors, images, video backgrounds
-- [references/text-overlays.md](references/text-overlays.md) - Adding text with fonts and positioning
-- [references/captions.md](references/captions.md) - Auto-generated captions and subtitles
+**Core workflow:**
+- [references/video-generation.md](references/video-generation.md) — `POST /v3/videos` request fields, avatar input modes, voice settings, backgrounds
+- [references/avatars.md](references/avatars.md) — `GET /v3/avatars` (groups) and `GET /v3/avatars/looks` (looks → `avatar_id`)
+- [references/voices.md](references/voices.md) — `GET /v3/voices` with filtering by language, gender, engine
+- [references/video-status.md](references/video-status.md) — `GET /v3/videos/{id}` polling patterns and download
 
-### Advanced Features
-- [references/templates.md](references/templates.md) - Template listing and variable replacement
-- [references/photo-avatars.md](references/photo-avatars.md) - Creating avatars from photos
-- [references/webhooks.md](references/webhooks.md) - Webhook endpoints and events
+**Customization:**
+- [references/scripts.md](references/scripts.md) — Script writing, SSML break tags, pacing
+- [references/backgrounds.md](references/backgrounds.md) — Solid color and image backgrounds
+- [references/captions.md](references/captions.md) — Auto-generated captions/subtitles
+- [references/text-overlays.md](references/text-overlays.md) — Text overlays with fonts and positioning
 
-### Integration
-- [references/remotion-integration.md](references/remotion-integration.md) - Using HeyGen in Remotion compositions
-
-### Foundation
-- [references/video-status.md](references/video-status.md) - Polling patterns and download URLs
-- [references/assets.md](references/assets.md) - Uploading images, videos, audio
-- [references/dimensions.md](references/dimensions.md) - Resolution and aspect ratios
-- [references/quota.md](references/quota.md) - Credit system and usage limits
+**Advanced:**
+- [references/photo-avatars.md](references/photo-avatars.md) — Animate photos via `type: "image"` (Avatar IV), AI-generated avatars
+- [references/templates.md](references/templates.md) — Template listing and variable replacement
+- [references/remotion-integration.md](references/remotion-integration.md) — Using HeyGen avatars in Remotion compositions
+- [references/webhooks.md](references/webhooks.md) — Webhook endpoints and events
+- [references/assets.md](references/assets.md) — Uploading images, videos, audio
+- [references/dimensions.md](references/dimensions.md) — Resolution and aspect ratios
+- [references/quota.md](references/quota.md) — Credit system and usage limits
 
 ## Best Practices
 
-1. **Preview avatars before generating** — Download `preview_image_url` so the user can see the avatar before committing
+1. **Preview avatars before generating** — Use `GET /v3/avatars/looks` and download `preview_image_url` so the user can see the avatar before committing
 2. **Use avatar's default voice** — Most avatars have a `default_voice_id` pre-matched for natural results
 3. **Fallback: match gender manually** — If no default voice, ensure avatar and voice genders match
 4. **Use test mode for development** — Set `test: true` to avoid consuming credits (output will be watermarked)

--- a/skills/avatar-video/references/assets.md
+++ b/skills/avatar-video/references/assets.md
@@ -309,13 +309,21 @@ async function createVideoWithCustomBackground(
 
   // 3. Generate video
   console.log("Generating video...");
-  const response = await fetch("https://api.heygen.com/v2/video/generate", {
+  const response = await fetch("https://api.heygen.com/v3/videos", {
     method: "POST",
     headers: {
       "X-Api-Key": process.env.HEYGEN_API_KEY!,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(config),
+    body: JSON.stringify({
+      type: "avatar" as const,
+      avatar_id: avatarId,
+      script: script,
+      voice_id: voiceId,
+      background: { type: "image", asset_id: bgAssetId },
+      resolution: "1080p",
+      aspect_ratio: "16:9",
+    }),
   });
 
   const { data } = await response.json();

--- a/skills/avatar-video/references/avatars.md
+++ b/skills/avatar-video/references/avatars.md
@@ -1,95 +1,107 @@
 ---
 name: avatars
-description: Listing avatars, avatar styles, and avatar_id selection for HeyGen
+description: Listing avatar groups and looks, filtering by type and ownership, and selecting the right avatar_id for video generation using the v3 API
 ---
 
 # HeyGen Avatars
 
-Avatars are the AI-generated presenters in HeyGen videos. You can use public avatars provided by HeyGen or create custom avatars.
+The v3 API organizes avatars into two levels:
+
+- **Groups** represent a character (e.g., "Josh", "Angela"). A group has a name, preview images, and a default voice.
+- **Looks** represent a specific outfit, style, or pose within a group. Each look has an `id` that you pass as `avatar_id` when creating a video via `POST /v3/videos`.
+
+A single group can have multiple looks. For example, the "Josh" group might have looks for business attire, casual wear, and seasonal outfits.
 
 ## Previewing Avatars Before Generation
 
-Always preview avatars before generating a video to ensure they match user preferences. Each avatar has preview URLs that can be opened directly in the browser - no downloading required.
+Always preview avatars before generating a video to ensure they match user preferences. Both groups and looks include preview URLs that can be opened directly in the browser.
 
-### List Avatars and Show Previews
+### Preview Fields
 
-```typescript
-async function listAndPreviewAvatars(openInBrowser = true): Promise<void> {
-  const response = await fetch("https://api.heygen.com/v2/avatars", {
-    headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
-  });
-  const { data } = await response.json();
+| Level | Field | Description |
+|-------|-------|-------------|
+| Group | `preview_image_url` | Static image of the character (publicly accessible) |
+| Group | `preview_video_url` | Short video clip showing the character |
+| Look | `preview_image_url` | Static image of this specific look/outfit |
+| Look | `preview_video_url` | Short video clip of this look in action |
 
-  for (const avatar of data.avatars.slice(0, 5)) {
-    console.log(`\n${avatar.avatar_name} (${avatar.gender})`);
-    console.log(`  ID: ${avatar.avatar_id}`);
-    console.log(`  Preview: ${avatar.preview_image_url}`);
-  }
-
-  // Preview URLs can be opened directly in any browser
-  for (const avatar of data.avatars.slice(0, 3)) {
-    console.log(`Open in browser: ${avatar.preview_image_url}`);
-  }
-}
-```
+Both URLs are publicly accessible -- no authentication needed to view them.
 
 ### Workflow: Preview Before Generate
 
-1. **List available avatars** - get names, genders, and preview URLs
-2. **Show preview URLs to user** - share `preview_image_url` for visual check
-3. **User selects** preferred avatar by name or ID
-4. **Get avatar details** for `default_voice_id`
-5. **Generate video** with selected avatar
+1. **List avatar groups** -- browse available characters
+2. **List looks for a group** -- see available outfits/styles
+3. **Show preview URLs to user** -- share `preview_image_url` for visual check
+4. **User selects** a look by name or ID
+5. **Use `look.id` as `avatar_id`** and `look.default_voice_id` as `voice_id` in `POST /v3/videos`
 
-### Preview Fields in API Response
+## Listing Avatar Groups
 
-| Field | Description |
-|-------|-------------|
-| `preview_image_url` | Static image of the avatar (JPG) - publicly accessible URL |
-| `preview_video_url` | Short video clip showing avatar animation |
-
-Both URLs are publicly accessible - no authentication needed to view.
-
-## Listing Available Avatars
+List all avatar groups (characters) available to your account.
 
 ### curl
 
 ```bash
-curl -X GET "https://api.heygen.com/v2/avatars" \
+# List public avatar groups
+curl -X GET "https://api.heygen.com/v3/avatars?ownership=public&limit=10" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+
+# List your private avatar groups
+curl -X GET "https://api.heygen.com/v3/avatars?ownership=private&limit=10" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
 ### TypeScript
 
 ```typescript
-interface Avatar {
-  avatar_id: string;
-  avatar_name: string;
-  gender: "male" | "female";
-  preview_image_url: string;
-  preview_video_url: string;
+interface AvatarGroupItem {
+  id: string;
+  name: string;
+  preview_image_url: string | null;
+  preview_video_url: string | null;
+  gender: string | null;
+  created_at: number;
+  looks_count: number;
+  default_voice_id: string | null;
 }
 
-interface AvatarsResponse {
-  error: null | string;
-  data: {
-    avatars: Avatar[];
-    talking_photos: TalkingPhoto[];
-  };
+interface AvatarGroupsResponse {
+  data: AvatarGroupItem[];
+  has_more: boolean;
+  next_token: string | null;
 }
 
-async function listAvatars(): Promise<Avatar[]> {
-  const response = await fetch("https://api.heygen.com/v2/avatars", {
-    headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
+async function listAvatarGroups(
+  ownership: "public" | "private" = "public",
+  limit: number = 50,
+  token?: string
+): Promise<AvatarGroupsResponse> {
+  const params = new URLSearchParams({
+    ownership,
+    limit: limit.toString(),
   });
-
-  const json: AvatarsResponse = await response.json();
-
-  if (json.error) {
-    throw new Error(json.error);
+  if (token) {
+    params.set("token", token);
   }
 
-  return json.data.avatars;
+  const response = await fetch(
+    `https://api.heygen.com/v3/avatars?${params}`,
+    { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to list avatar groups: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// Usage
+const { data: groups, has_more, next_token } = await listAvatarGroups("public", 10);
+for (const group of groups) {
+  console.log(`${group.name} (${group.gender}) - ${group.looks_count} looks`);
+  console.log(`  ID: ${group.id}`);
+  console.log(`  Preview: ${group.preview_image_url}`);
 }
 ```
 
@@ -99,401 +111,612 @@ async function listAvatars(): Promise<Avatar[]> {
 import requests
 import os
 
-def list_avatars() -> list:
+
+def list_avatar_groups(
+    ownership: str = "public",
+    limit: int = 50,
+    token: str | None = None,
+) -> dict:
+    params = {"ownership": ownership, "limit": limit}
+    if token:
+        params["token"] = token
+
     response = requests.get(
-        "https://api.heygen.com/v2/avatars",
-        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]}
+        "https://api.heygen.com/v3/avatars",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        params=params,
     )
+    response.raise_for_status()
+    return response.json()
 
-    data = response.json()
-    if data.get("error"):
-        raise Exception(data["error"])
 
-    return data["data"]["avatars"]
+# Usage
+result = list_avatar_groups("public", limit=10)
+for group in result["data"]:
+    print(f"{group['name']} ({group['gender']}) - {group['looks_count']} looks")
+    print(f"  ID: {group['id']}")
+    print(f"  Preview: {group['preview_image_url']}")
 ```
 
-## Response Format
+### Response Format
 
 ```json
 {
-  "error": null,
-  "data": {
-    "avatars": [
-      {
-        "avatar_id": "josh_lite3_20230714",
-        "avatar_name": "Josh",
-        "gender": "male",
-        "preview_image_url": "https://files.heygen.ai/...",
-        "preview_video_url": "https://files.heygen.ai/..."
-      },
-      {
-        "avatar_id": "angela_expressive_20231010",
-        "avatar_name": "Angela",
-        "gender": "female",
-        "preview_image_url": "https://files.heygen.ai/...",
-        "preview_video_url": "https://files.heygen.ai/..."
-      }
-    ],
-    "talking_photos": []
-  }
+  "data": [
+    {
+      "id": "ag_abc123",
+      "name": "Josh",
+      "preview_image_url": "https://files.heygen.ai/...",
+      "preview_video_url": "https://files.heygen.ai/...",
+      "gender": "male",
+      "created_at": 1710000000,
+      "looks_count": 3,
+      "default_voice_id": "1bd001e7e50f421d891986aad5158bc8"
+    },
+    {
+      "id": "ag_def456",
+      "name": "Angela",
+      "preview_image_url": "https://files.heygen.ai/...",
+      "preview_video_url": "https://files.heygen.ai/...",
+      "gender": "female",
+      "created_at": 1710100000,
+      "looks_count": 2,
+      "default_voice_id": "2d5b0e6a8c3f47d9a1b2c3d4e5f60718"
+    }
+  ],
+  "has_more": true,
+  "next_token": "eyJsYXN0X2lkIjoiYWdfZGVmNDU2In0="
 }
+```
+
+## Get Avatar Group Details
+
+Retrieve details for a single avatar group by its ID.
+
+### curl
+
+```bash
+curl -X GET "https://api.heygen.com/v3/avatars/ag_abc123" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+### TypeScript
+
+```typescript
+async function getAvatarGroup(groupId: string): Promise<AvatarGroupItem> {
+  const response = await fetch(
+    `https://api.heygen.com/v3/avatars/${groupId}`,
+    { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to get avatar group: ${response.status}`);
+  }
+
+  return response.json();
+}
+```
+
+### Python
+
+```python
+def get_avatar_group(group_id: str) -> dict:
+    response = requests.get(
+        f"https://api.heygen.com/v3/avatars/{group_id}",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+## Listing Avatar Looks
+
+Looks are the specific outfits, styles, or poses within a group. The look `id` is what you pass as `avatar_id` to `POST /v3/videos`.
+
+### curl
+
+```bash
+# List all public looks
+curl -X GET "https://api.heygen.com/v3/avatars/looks?ownership=public&limit=20" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+
+# List looks for a specific group
+curl -X GET "https://api.heygen.com/v3/avatars/looks?group_id=ag_abc123&limit=20" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+
+# List only studio avatars
+curl -X GET "https://api.heygen.com/v3/avatars/looks?avatar_type=studio_avatar&ownership=public&limit=20" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `group_id` | string | No | Filter looks by avatar group |
+| `avatar_type` | string | No | `"studio_avatar"`, `"video_avatar"`, or `"photo_avatar"` |
+| `ownership` | string | No | `"public"` or `"private"` |
+| `limit` | integer | No | 1-50, number of results per page |
+| `token` | string | No | Cursor token for pagination |
+
+### TypeScript
+
+```typescript
+interface AvatarLookItem {
+  id: string;
+  name: string;
+  avatar_type: "studio_avatar" | "video_avatar" | "photo_avatar";
+  group_id: string | null;
+  preview_image_url: string | null;
+  preview_video_url: string | null;
+  gender: string | null;
+  tags: string[];
+  default_voice_id: string | null;
+  supported_api_engines: string[];
+}
+
+interface AvatarLooksResponse {
+  data: AvatarLookItem[];
+  has_more: boolean;
+  next_token: string | null;
+}
+
+async function listAvatarLooks(options: {
+  group_id?: string;
+  avatar_type?: "studio_avatar" | "video_avatar" | "photo_avatar";
+  ownership?: "public" | "private";
+  limit?: number;
+  token?: string;
+} = {}): Promise<AvatarLooksResponse> {
+  const params = new URLSearchParams();
+
+  if (options.group_id) params.set("group_id", options.group_id);
+  if (options.avatar_type) params.set("avatar_type", options.avatar_type);
+  if (options.ownership) params.set("ownership", options.ownership);
+  if (options.limit) params.set("limit", options.limit.toString());
+  if (options.token) params.set("token", options.token);
+
+  const response = await fetch(
+    `https://api.heygen.com/v3/avatars/looks?${params}`,
+    { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to list avatar looks: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// List all public looks
+const { data: looks } = await listAvatarLooks({ ownership: "public", limit: 20 });
+
+// List looks for a specific group
+const { data: groupLooks } = await listAvatarLooks({ group_id: "ag_abc123" });
+
+// List only studio avatars
+const { data: studioLooks } = await listAvatarLooks({
+  avatar_type: "studio_avatar",
+  ownership: "public",
+});
+```
+
+### Python
+
+```python
+def list_avatar_looks(
+    group_id: str | None = None,
+    avatar_type: str | None = None,
+    ownership: str | None = None,
+    limit: int = 50,
+    token: str | None = None,
+) -> dict:
+    params: dict = {"limit": limit}
+    if group_id:
+        params["group_id"] = group_id
+    if avatar_type:
+        params["avatar_type"] = avatar_type
+    if ownership:
+        params["ownership"] = ownership
+    if token:
+        params["token"] = token
+
+    response = requests.get(
+        "https://api.heygen.com/v3/avatars/looks",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        params=params,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# List all public looks
+result = list_avatar_looks(ownership="public", limit=20)
+for look in result["data"]:
+    print(f"{look['name']} ({look['avatar_type']}) - ID: {look['id']}")
+
+# List looks for a specific group
+result = list_avatar_looks(group_id="ag_abc123")
+
+# List only studio avatars
+result = list_avatar_looks(avatar_type="studio_avatar", ownership="public")
+```
+
+### Response Format
+
+```json
+{
+  "data": [
+    {
+      "id": "lk_josh_business",
+      "name": "Josh - Business",
+      "avatar_type": "studio_avatar",
+      "group_id": "ag_abc123",
+      "preview_image_url": "https://files.heygen.ai/...",
+      "preview_video_url": "https://files.heygen.ai/...",
+      "gender": "male",
+      "tags": ["business", "professional"],
+      "default_voice_id": "1bd001e7e50f421d891986aad5158bc8",
+      "supported_api_engines": ["avatar_4_quality", "avatar_4_turbo"]
+    },
+    {
+      "id": "lk_josh_casual",
+      "name": "Josh - Casual",
+      "avatar_type": "studio_avatar",
+      "group_id": "ag_abc123",
+      "preview_image_url": "https://files.heygen.ai/...",
+      "preview_video_url": "https://files.heygen.ai/...",
+      "gender": "male",
+      "tags": ["casual", "lifestyle"],
+      "default_voice_id": "1bd001e7e50f421d891986aad5158bc8",
+      "supported_api_engines": ["avatar_4_quality", "avatar_4_turbo"]
+    }
+  ],
+  "has_more": false,
+  "next_token": null
+}
+```
+
+## Get Look Details
+
+Retrieve details for a single look by its ID.
+
+### curl
+
+```bash
+curl -X GET "https://api.heygen.com/v3/avatars/looks/lk_josh_business" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+### TypeScript
+
+```typescript
+async function getAvatarLook(lookId: string): Promise<AvatarLookItem> {
+  const response = await fetch(
+    `https://api.heygen.com/v3/avatars/looks/${lookId}`,
+    { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to get avatar look: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// Usage
+const look = await getAvatarLook("lk_josh_business");
+console.log(`${look.name} (${look.avatar_type})`);
+console.log(`Engines: ${look.supported_api_engines.join(", ")}`);
+console.log(`Default voice: ${look.default_voice_id}`);
+```
+
+### Python
+
+```python
+def get_avatar_look(look_id: str) -> dict:
+    response = requests.get(
+        f"https://api.heygen.com/v3/avatars/looks/{look_id}",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# Usage
+look = get_avatar_look("lk_josh_business")
+print(f"{look['name']} ({look['avatar_type']})")
+print(f"Engines: {', '.join(look['supported_api_engines'])}")
+print(f"Default voice: {look['default_voice_id']}")
 ```
 
 ## Avatar Types
 
-### Public Avatars
+The `avatar_type` field on looks distinguishes three categories:
 
-HeyGen provides a library of public avatars that anyone can use:
+| Type | Description | Best For |
+|------|-------------|----------|
+| `studio_avatar` | Professionally produced studio-quality avatars | Corporate videos, product demos, training content |
+| `video_avatar` | Avatars trained from uploaded video footage | Custom brand representatives, personalized content |
+| `photo_avatar` | Avatars generated from a still photo | Quick prototyping, low-effort personalization |
 
-```typescript
-// List only public avatars
-const avatars = await listAvatars();
-const publicAvatars = avatars.filter((a) => !a.avatar_id.startsWith("custom_"));
-```
-
-### Private/Custom Avatars
-
-Custom avatars created from your own training footage:
+### Filtering by Type
 
 ```typescript
-const customAvatars = avatars.filter((a) => a.avatar_id.startsWith("custom_"));
+// Get only studio avatars (highest quality)
+const { data: studioLooks } = await listAvatarLooks({
+  avatar_type: "studio_avatar",
+  ownership: "public",
+});
+
+// Get only photo avatars (from uploaded photos)
+const { data: photoLooks } = await listAvatarLooks({
+  avatar_type: "photo_avatar",
+  ownership: "private",
+});
 ```
 
-## Avatar Styles
-
-Avatars support different rendering styles:
-
-| Style | Description |
-|-------|-------------|
-| `normal` | Full body shot, standard framing |
-| `closeUp` | Close-up on face, more expressive |
-| `circle` | Avatar in circular frame (talking head) |
-| `voice_only` | Audio only, no video rendering |
-
-### When to Use Each Style
-
-| Use Case | Recommended Style |
-|----------|-------------------|
-| Full-screen presenter video | `normal` |
-| Personal/intimate content | `closeUp` |
-| Picture-in-picture overlay | `circle` |
-| Small corner widget | `circle` |
-| Podcast/audio content | `voice_only` |
-| Motion graphics with avatar overlay | `normal` or `closeUp` + transparent bg |
-
-### Using Avatar Styles
-
-```typescript
-const videoConfig = {
-  video_inputs: [
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal", // "normal" | "closeUp" | "circle" | "voice_only"
-      },
-      voice: {
-        type: "text",
-        input_text: "Hello, world!",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-      },
-    },
-  ],
-};
-```
-
-### Circle Style for Talking Heads
-
-Circle style is ideal for overlay compositions:
-
-```typescript
-// Circle avatar for picture-in-picture
-{
-  character: {
-    type: "avatar",
-    avatar_id: "josh_lite3_20230714",
-    avatar_style: "circle",
-  },
-  voice: { ... },
-  background: {
-    type: "color",
-    value: "#00FF00", // Green for chroma key, or use webm endpoint
-  },
-}
-```
-
-## Searching and Filtering Avatars
-
-### By Gender
-
-```typescript
-function filterByGender(avatars: Avatar[], gender: "male" | "female"): Avatar[] {
-  return avatars.filter((a) => a.gender === gender);
-}
-
-const maleAvatars = filterByGender(avatars, "male");
-const femaleAvatars = filterByGender(avatars, "female");
-```
-
-### By Name
-
-```typescript
-function searchByName(avatars: Avatar[], query: string): Avatar[] {
-  const lowerQuery = query.toLowerCase();
-  return avatars.filter((a) =>
-    a.avatar_name.toLowerCase().includes(lowerQuery)
-  );
-}
-
-const results = searchByName(avatars, "josh");
-```
-
-## Avatar Groups
-
-Avatars are organized into groups for better management.
-
-### List Avatar Groups
-
-```bash
-curl -X GET "https://api.heygen.com/v2/avatar_group.list?include_public=true" \
-  -H "X-Api-Key: $HEYGEN_API_KEY"
-```
-
-#### Query Parameters
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `include_public` | bool | false | Include public avatars in results |
-
-#### TypeScript
-
-```typescript
-interface AvatarGroupItem {
-  id: string;
-  name: string;
-  created_at: number;
-  num_looks: number;
-  preview_image: string;
-  group_type: string;
-  train_status: string;
-  default_voice_id: string | null;
-}
-
-interface AvatarGroupListResponse {
-  error: null | string;
-  data: {
-    avatar_group_list: AvatarGroupItem[];
-  };
-}
-
-async function listAvatarGroups(
-  includePublic = true
-): Promise<AvatarGroupListResponse["data"]> {
-  const params = new URLSearchParams({
-    include_public: includePublic.toString(),
-  });
-
-  const response = await fetch(
-    `https://api.heygen.com/v2/avatar_group.list?${params}`,
-    { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
-  );
-
-  const json: AvatarGroupListResponse = await response.json();
-
-  if (json.error) {
-    throw new Error(json.error);
-  }
-
-  return json.data;
-}
-```
-
-### Get Avatars in a Group
-
-```bash
-curl -X GET "https://api.heygen.com/v2/avatar_group/{group_id}/avatars" \
-  -H "X-Api-Key: $HEYGEN_API_KEY"
-```
-
-## Using Avatars in Video Generation
-
-### Basic Avatar Usage
-
-```typescript
-const videoConfig = {
-  video_inputs: [
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: "Welcome to our product demo!",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-      },
-    },
-  ],
-  dimension: { width: 1920, height: 1080 },
-};
-```
-
-### Multiple Scenes with Different Avatars
-
-```typescript
-const multiSceneConfig = {
-  video_inputs: [
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: "Hi, I'm Josh. Let me introduce my colleague.",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-      },
-    },
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "angela_expressive_20231010",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: "Hello! I'm Angela. Nice to meet you!",
-        voice_id: "2d5b0e6a8c3f47d9a1b2c3d4e5f60718",
-      },
-    },
-  ],
-};
+```python
+# Get only video avatars (trained from video footage)
+result = list_avatar_looks(avatar_type="video_avatar", ownership="private")
 ```
 
 ## Using Avatar's Default Voice
 
-Many avatars have a `default_voice_id` that's pre-matched for natural results. **This is the recommended approach** rather than manually selecting voices.
+Each look has a `default_voice_id` that is pre-matched for natural results. This is the recommended approach rather than manually selecting voices.
 
 ### Recommended Flow
 
 ```
-1. GET /v2/avatars           → Get list of avatar_ids
-2. GET /v2/avatar/{id}/details → Get default_voice_id for chosen avatar
-3. POST /v2/video/generate   → Use avatar_id + default_voice_id
+1. GET /v3/avatars/looks      -> Pick a look
+2. Use look.id as avatar_id   -> Pass to POST /v3/videos
+3. Use look.default_voice_id  -> Pass as voice_id to POST /v3/videos
 ```
 
-### Get Avatar Details (v2 API)
-
-Given an `avatar_id`, fetch its details including the default voice:
-
-```bash
-curl -X GET "https://api.heygen.com/v2/avatar/{avatar_id}/details" \
-  -H "X-Api-Key: $HEYGEN_API_KEY"
-```
-
-#### Response Format
-
-```json
-{
-  "error": null,
-  "data": {
-    "type": "avatar",
-    "id": "josh_lite3_20230714",
-    "name": "Josh",
-    "gender": "male",
-    "preview_image_url": "https://files.heygen.ai/...",
-    "preview_video_url": "https://files.heygen.ai/...",
-    "premium": false,
-    "is_public": true,
-    "default_voice_id": "1bd001e7e50f421d891986aad5158bc8",
-    "tags": ["AVATAR_IV"]
-  }
-}
-```
+### Complete Example: Generate Video with a Look's Default Voice
 
 #### TypeScript
 
 ```typescript
-interface AvatarDetails {
-  type: "avatar";
-  id: string;
-  name: string;
-  gender: "male" | "female";
-  preview_image_url: string;
-  preview_video_url: string;
-  premium: boolean;
-  is_public: boolean;
-  default_voice_id: string | null;
-  tags: string[];
-}
+async function generateWithDefaultVoice(
+  lookId: string,
+  script: string
+): Promise<string> {
+  // 1. Get look details to find default voice
+  const look = await getAvatarLook(lookId);
 
-async function getAvatarDetails(avatarId: string): Promise<AvatarDetails> {
-  const response = await fetch(
-    `https://api.heygen.com/v2/avatar/${avatarId}/details`,
-    { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
-  );
-
-  const json = await response.json();
-
-  if (json.error) {
-    throw new Error(json.error);
+  if (!look.default_voice_id) {
+    throw new Error(`Look ${look.name} has no default voice`);
   }
 
-  return json.data;
-}
+  console.log(`Using ${look.name} with default voice: ${look.default_voice_id}`);
 
-// Usage: Get default voice for a known avatar
-const details = await getAvatarDetails("josh_lite3_20230714");
-if (details.default_voice_id) {
-  console.log(`Using ${details.name} with default voice: ${details.default_voice_id}`);
-} else {
-  console.log(`${details.name} has no default voice, select manually`);
+  // 2. Generate video with the look's default voice
+  const response = await fetch("https://api.heygen.com/v3/videos", {
+    method: "POST",
+    headers: {
+      "X-Api-Key": process.env.HEYGEN_API_KEY!,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      video_inputs: [{
+        character: {
+          type: "avatar",
+          avatar_id: look.id,       // The look ID is the avatar_id
+          avatar_style: "normal",
+        },
+        voice: {
+          type: "text",
+          input_text: script,
+          voice_id: look.default_voice_id,
+        },
+      }],
+      dimension: { width: 1920, height: 1080 },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Video generation failed: ${response.status}`);
+  }
+
+  const { data } = await response.json();
+  return data.video_id;
 }
 ```
 
-#### Complete Example: Generate Video with Any Avatar's Default Voice
+#### Python
 
-```typescript
-async function generateWithAvatarDefaultVoice(
-  avatarId: string,
-  script: string
-): Promise<string> {
-  // 1. Get avatar details to find default voice
-  const avatar = await getAvatarDetails(avatarId);
+```python
+def generate_with_default_voice(look_id: str, script: str) -> str:
+    # 1. Get look details to find default voice
+    look = get_avatar_look(look_id)
 
-  if (!avatar.default_voice_id) {
-    throw new Error(`Avatar ${avatar.name} has no default voice`);
-  }
+    if not look.get("default_voice_id"):
+        raise ValueError(f"Look {look['name']} has no default voice")
 
-  // 2. Generate video with the avatar's default voice
-  const videoId = await generateVideo({
-    video_inputs: [{
-      character: {
-        type: "avatar",
-        avatar_id: avatar.id,
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: script,
-        voice_id: avatar.default_voice_id,
-      },
-    }],
-    dimension: { width: 1920, height: 1080 },
-  });
+    print(f"Using {look['name']} with default voice: {look['default_voice_id']}")
 
-  return videoId;
-}
+    # 2. Generate video with the look's default voice
+    response = requests.post(
+        "https://api.heygen.com/v3/videos",
+        headers={
+            "X-Api-Key": os.environ["HEYGEN_API_KEY"],
+            "Content-Type": "application/json",
+        },
+        json={
+            "video_inputs": [{
+                "character": {
+                    "type": "avatar",
+                    "avatar_id": look["id"],       # The look ID is the avatar_id
+                    "avatar_style": "normal",
+                },
+                "voice": {
+                    "type": "text",
+                    "input_text": script,
+                    "voice_id": look["default_voice_id"],
+                },
+            }],
+            "dimension": {"width": 1920, "height": 1080},
+        },
+    )
+    response.raise_for_status()
+    return response.json()["data"]["video_id"]
 ```
 
 ### Why Use Default Voice?
 
-1. **Guaranteed gender match** - Avatar and voice are pre-paired
-2. **Natural lip sync** - Default voices are optimized for the avatar
-3. **Simpler code** - No need to fetch and match voices separately
-4. **Better quality** - HeyGen has tested this combination
+1. **Guaranteed gender match** -- avatar and voice are pre-paired
+2. **Natural lip sync** -- default voices are optimized for the avatar
+3. **Simpler code** -- no need to fetch and match voices separately
+4. **Better quality** -- HeyGen has tested this combination
+
+## Filtering and Searching
+
+The v3 API supports server-side filtering across multiple dimensions.
+
+### By Group
+
+```typescript
+// Get all looks for a specific character
+const { data: looks } = await listAvatarLooks({ group_id: "ag_abc123" });
+```
+
+### By Avatar Type
+
+```typescript
+// Only studio-quality avatars
+const { data: looks } = await listAvatarLooks({ avatar_type: "studio_avatar" });
+```
+
+### By Ownership
+
+```typescript
+// Public avatars provided by HeyGen
+const { data: publicLooks } = await listAvatarLooks({ ownership: "public" });
+
+// Your custom/private avatars
+const { data: privateLooks } = await listAvatarLooks({ ownership: "private" });
+```
+
+### By Gender (Client-Side)
+
+Gender is available on the response but not as a query parameter. Filter client-side:
+
+```typescript
+const { data: looks } = await listAvatarLooks({ ownership: "public" });
+const femaleLooks = looks.filter((look) => look.gender === "female");
+const maleLooks = looks.filter((look) => look.gender === "male");
+```
+
+```python
+result = list_avatar_looks(ownership="public")
+female_looks = [look for look in result["data"] if look["gender"] == "female"]
+male_looks = [look for look in result["data"] if look["gender"] == "male"]
+```
+
+### Combining Filters
+
+```typescript
+// Private studio avatars for a specific group
+const { data: looks } = await listAvatarLooks({
+  group_id: "ag_abc123",
+  avatar_type: "studio_avatar",
+  ownership: "private",
+  limit: 10,
+});
+```
+
+### Search by Name (Client-Side)
+
+```typescript
+function searchLooksByName(looks: AvatarLookItem[], query: string): AvatarLookItem[] {
+  const lowerQuery = query.toLowerCase();
+  return looks.filter((look) =>
+    look.name.toLowerCase().includes(lowerQuery)
+  );
+}
+
+const { data: allLooks } = await listAvatarLooks({ ownership: "public" });
+const results = searchLooksByName(allLooks, "josh");
+```
+
+## Cursor-Based Pagination
+
+Both the groups and looks endpoints use cursor-based pagination. The response includes `has_more` (boolean) and `next_token` (string or null). Pass `next_token` as the `token` query parameter to fetch the next page.
+
+### TypeScript
+
+```typescript
+async function listAllAvatarLooks(
+  options: { ownership?: "public" | "private"; avatar_type?: string } = {}
+): Promise<AvatarLookItem[]> {
+  const allLooks: AvatarLookItem[] = [];
+  let token: string | undefined;
+
+  do {
+    const response = await listAvatarLooks({
+      ...options,
+      limit: 50,
+      token,
+    });
+
+    allLooks.push(...response.data);
+    token = response.has_more && response.next_token
+      ? response.next_token
+      : undefined;
+  } while (token);
+
+  return allLooks;
+}
+
+// Fetch every public look across all pages
+const allPublicLooks = await listAllAvatarLooks({ ownership: "public" });
+console.log(`Total public looks: ${allPublicLooks.length}`);
+```
+
+### Python
+
+```python
+def list_all_avatar_looks(
+    ownership: str | None = None,
+    avatar_type: str | None = None,
+) -> list[dict]:
+    all_looks: list[dict] = []
+    token: str | None = None
+
+    while True:
+        result = list_avatar_looks(
+            ownership=ownership,
+            avatar_type=avatar_type,
+            limit=50,
+            token=token,
+        )
+
+        all_looks.extend(result["data"])
+
+        if not result["has_more"] or not result.get("next_token"):
+            break
+        token = result["next_token"]
+
+    return all_looks
+
+
+# Fetch every public look across all pages
+all_public_looks = list_all_avatar_looks(ownership="public")
+print(f"Total public looks: {len(all_public_looks)}")
+```
+
+### curl (Manual Pagination)
+
+```bash
+# First page
+curl -X GET "https://api.heygen.com/v3/avatars/looks?ownership=public&limit=50" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+
+# Next page (use next_token from previous response)
+curl -X GET "https://api.heygen.com/v3/avatars/looks?ownership=public&limit=50&token=eyJsYXN0X2lkIjoiLi4uIn0=" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
 
 ## Selecting the Right Avatar
 
@@ -501,86 +724,50 @@ async function generateWithAvatarDefaultVoice(
 
 HeyGen avatars fall into distinct categories. Match the category to your use case:
 
-| Category | Examples | Best For |
-|----------|----------|----------|
-| **Business/Professional** | Josh, Angela, Wayne | Corporate videos, product demos, training |
-| **Casual/Friendly** | Lily, various lifestyle avatars | Social media, informal content |
-| **Themed/Seasonal** | Holiday-themed, costume avatars | Specific campaigns, seasonal content |
-| **Expressive** | Avatars with "expressive" in name | Engaging storytelling, dynamic content |
+| Category | Best For |
+|----------|----------|
+| **Business/Professional** | Corporate videos, product demos, training |
+| **Casual/Friendly** | Social media, informal content |
+| **Themed/Seasonal** | Specific campaigns, seasonal content |
+| **Expressive** | Engaging storytelling, dynamic content |
 
 ### Selection Guidelines
 
 **For business/professional content:**
-- Choose avatars with neutral attire (business casual or formal)
-- Avoid themed or seasonal avatars (holiday costumes, casual clothing)
-- Preview the avatar to verify professional appearance
+- Choose looks with neutral attire (business casual or formal)
+- Avoid themed or seasonal looks (holiday costumes, casual clothing)
+- Preview the look to verify professional appearance
 - Consider your audience demographics when selecting gender and appearance
+- Prefer `studio_avatar` type for highest quality
 
 **For casual/social content:**
-- More flexibility in avatar choice
-- Themed avatars can work for specific campaigns
+- More flexibility in look choice
+- Themed looks can work for specific campaigns
 - Match avatar energy to content tone
 
 ### Common Mistakes to Avoid
 
-1. **Using themed avatars for business content** - A holiday-themed avatar looks unprofessional in a product demo
-2. **Not previewing before generation** - Always check the preview URL to verify appearance
-3. **Ignoring avatar style** - A `circle` style avatar may not work for full-screen presentations
-4. **Mismatched voice gender** - Always use the avatar's `default_voice_id` or match genders manually
+1. **Using themed looks for business content** -- a holiday-themed look appears unprofessional in a product demo
+2. **Not previewing before generation** -- always check the preview URL to verify appearance
+3. **Mismatched voice gender** -- always use the look's `default_voice_id` or match genders manually
+4. **Using a group ID instead of a look ID** -- `POST /v3/videos` requires a look `id`, not a group `id`
 
 ### Selection Checklist
 
 Before generating a video:
-- [ ] Previewed avatar image/video in browser
-- [ ] Avatar appearance matches content tone (professional vs casual)
-- [ ] Avatar style (`normal`, `closeUp`, `circle`) fits the video format
+- [ ] Previewed look image/video in browser
+- [ ] Look appearance matches content tone (professional vs casual)
 - [ ] Voice gender matches avatar gender
 - [ ] Using `default_voice_id` when available
+- [ ] Passing the look `id` (not the group `id`) as `avatar_id`
+- [ ] Checked `supported_api_engines` if targeting a specific rendering engine
 
-## Helper Functions
+## Best Practices
 
-### Get Avatar by ID
-
-```typescript
-async function getAvatarById(avatarId: string): Promise<Avatar | null> {
-  const avatars = await listAvatars();
-  return avatars.find((a) => a.avatar_id === avatarId) || null;
-}
-```
-
-### Validate Avatar ID
-
-```typescript
-async function isValidAvatarId(avatarId: string): Promise<boolean> {
-  const avatar = await getAvatarById(avatarId);
-  return avatar !== null;
-}
-```
-
-### Get Random Avatar
-
-```typescript
-async function getRandomAvatar(gender?: "male" | "female"): Promise<Avatar> {
-  let avatars = await listAvatars();
-
-  if (gender) {
-    avatars = avatars.filter((a) => a.gender === gender);
-  }
-
-  const randomIndex = Math.floor(Math.random() * avatars.length);
-  return avatars[randomIndex];
-}
-```
-
-## Common Avatar IDs
-
-Some commonly used public avatar IDs (availability may vary):
-
-| Avatar ID | Name | Gender |
-|-----------|------|--------|
-| `josh_lite3_20230714` | Josh | Male |
-| `angela_expressive_20231010` | Angela | Female |
-| `wayne_20240422` | Wayne | Male |
-| `lily_20230614` | Lily | Female |
-
-Always verify avatar availability by calling the list endpoint before using.
+1. **Always use look IDs for video generation.** The look `id` is the `avatar_id` you pass to `POST /v3/videos`. Group IDs are for browsing and organization only.
+2. **Prefer `default_voice_id`.** Each look has a pre-matched voice. Use it unless the user explicitly requests a different voice.
+3. **Preview before generating.** Share `preview_image_url` with the user to confirm the look matches their expectations.
+4. **Use server-side filters.** Filter by `ownership`, `avatar_type`, and `group_id` at the API level rather than fetching everything and filtering client-side.
+5. **Paginate large result sets.** Use `limit` and `token` to page through results. The maximum `limit` is 50.
+6. **Check `supported_api_engines`.** Some looks support `avatar_4_quality` (higher quality, slower) and `avatar_4_turbo` (faster). Choose based on your latency and quality requirements.
+7. **Cache group and look lists.** Avatar catalogs change infrequently. Cache the results for a reasonable period to reduce API calls.

--- a/skills/avatar-video/references/dimensions.md
+++ b/skills/avatar-video/references/dimensions.md
@@ -67,15 +67,16 @@ const squareConfig = {
 
 ```bash
 # Landscape 1080p
-curl -X POST "https://api.heygen.com/v2/video/generate" \
+curl -X POST "https://api.heygen.com/v3/videos" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "video_inputs": [...],
-    "dimension": {
-      "width": 1920,
-      "height": 1080
-    }
+    "type": "avatar",
+    "avatar_id": "YOUR_AVATAR_LOOK_ID",
+    "script": "Hello!",
+    "voice_id": "YOUR_VOICE_ID",
+    "resolution": "1080p",
+    "aspect_ratio": "16:9"
   }'
 ```
 

--- a/skills/avatar-video/references/photo-avatars.md
+++ b/skills/avatar-video/references/photo-avatars.md
@@ -1,19 +1,270 @@
 ---
 name: photo-avatars
-description: Creating avatars from photos (talking photos) for HeyGen
+description: Animating photos into high-quality videos using HeyGen's v3 API with Avatar IV technology
 ---
 
-# Photo Avatars (Talking Photos)
+# Photo Avatars
 
-Photo avatars allow you to animate a static photo and make it speak. This is useful for creating personalized video content from portraits, headshots, or any suitable image.
+Animate a static photo into a speaking video. Use `POST /v3/videos` with `"type": "image"` and a nested `image` field (AssetInput discriminated union: `{ "type": "url", "url": "..." }` or `{ "type": "asset_id", "asset_id": "..." }`) — this uses Avatar IV technology automatically for high-quality results, no avatar group creation needed.
 
-## Creating a Photo Avatar from an Uploaded Image
+## Direct Image-to-Video (v3 API)
 
-The workflow is: **Upload Image → Create Avatar Group → Use in Video**
+### Request Fields
 
-### Step 1: Upload the Image
+| Field | Type | Req | Description |
+|-------|------|:---:|-------------|
+| `type` | string | ✓ | Must be `"image"` |
+| `image` | AssetInput | ✓ | Image to animate. Either `{ "type": "url", "url": "..." }` for a public URL, or `{ "type": "asset_id", "asset_id": "..." }` for an uploaded asset. |
+| `script` | string | ✓ | Text for the avatar to speak |
+| `voice_id` | string | ✓ | Voice to use |
+| `motion_prompt` | string | | Natural-language prompt controlling body motion (photo avatars only) |
+| `expressiveness` | string | | `"high"`, `"medium"`, or `"low"` (photo avatars only, defaults to `"low"`) |
+| `aspect_ratio` | string | | `"16:9"` or `"9:16"` |
+| `resolution` | string | | `"1080p"` or `"720p"` |
+| `remove_background` | boolean | | Remove background from the photo |
 
-Upload a portrait photo using the asset upload endpoint. The response includes an `image_key` which you'll use in the next step.
+**AssetInput** is a discriminated union on the `type` field:
+- URL variant: `{ "type": "url", "url": "https://example.com/photo.jpg" }`
+- Asset ID variant: `{ "type": "asset_id", "asset_id": "uploaded_asset_id" }`
+
+### curl Example
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "image",
+    "image": { "type": "url", "url": "https://example.com/portrait.jpg" },
+    "script": "Hello! This is a high-quality photo avatar video.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "aspect_ratio": "16:9",
+    "resolution": "1080p"
+  }'
+```
+
+Response:
+```json
+{
+  "error": null,
+  "data": {
+    "video_id": "abc123def456"
+  }
+}
+```
+
+### TypeScript Example
+
+```typescript
+type AssetInput =
+  | { type: "url"; url: string }
+  | { type: "asset_id"; asset_id: string };
+
+interface PhotoVideoRequest {
+  type: "image";
+  image: AssetInput;
+  script: string;
+  voice_id: string;
+  motion_prompt?: string;
+  expressiveness?: "high" | "medium" | "low";
+  aspect_ratio?: "16:9" | "9:16";
+  resolution?: "1080p" | "720p";
+  remove_background?: boolean;
+}
+
+interface VideoResponse {
+  error: string | null;
+  data: {
+    video_id: string;
+  };
+}
+
+interface VideoStatusResponse {
+  error: string | null;
+  data: {
+    video_id: string;
+    status: "pending" | "processing" | "completed" | "failed";
+    video_url?: string;
+    thumbnail_url?: string;
+    duration?: number;
+    error?: string;
+  };
+}
+
+async function createPhotoVideo(config: PhotoVideoRequest): Promise<string> {
+  const response = await fetch("https://api.heygen.com/v3/videos", {
+    method: "POST",
+    headers: {
+      "X-Api-Key": process.env.HEYGEN_API_KEY!,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(config),
+  });
+
+  const json: VideoResponse = await response.json();
+  if (json.error) {
+    throw new Error(json.error);
+  }
+
+  return json.data.video_id;
+}
+
+async function pollVideoStatus(videoId: string): Promise<string> {
+  for (let i = 0; i < 120; i++) {
+    const response = await fetch(
+      `https://api.heygen.com/v3/videos/${videoId}`,
+      { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
+    );
+
+    const json: VideoStatusResponse = await response.json();
+
+    if (json.data.status === "completed") {
+      return json.data.video_url!;
+    }
+    if (json.data.status === "failed") {
+      throw new Error(json.data.error ?? "Video generation failed");
+    }
+
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+
+  throw new Error("Video generation timed out");
+}
+
+// Usage
+const videoId = await createPhotoVideo({
+  type: "image",
+  image: { type: "url", url: "https://example.com/portrait.jpg" },
+  script: "Hello! This is a high-quality photo avatar video.",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  aspect_ratio: "16:9",
+  resolution: "1080p",
+});
+
+const videoUrl = await pollVideoStatus(videoId);
+console.log("Video ready:", videoUrl);
+```
+
+### Python Example
+
+```python
+import requests
+import os
+import time
+
+def create_photo_video(
+    script: str,
+    voice_id: str,
+    image_url: str | None = None,
+    image_asset_id: str | None = None,
+    motion_prompt: str | None = None,
+    expressiveness: str | None = None,
+    aspect_ratio: str = "16:9",
+    resolution: str = "1080p",
+    remove_background: bool = False,
+) -> str:
+    api_key = os.environ["HEYGEN_API_KEY"]
+
+    # Build the AssetInput discriminated union
+    if image_url:
+        image_input = {"type": "url", "url": image_url}
+    elif image_asset_id:
+        image_input = {"type": "asset_id", "asset_id": image_asset_id}
+    else:
+        raise ValueError("Provide either image_url or image_asset_id")
+
+    payload: dict = {
+        "type": "image",
+        "image": image_input,
+        "script": script,
+        "voice_id": voice_id,
+        "aspect_ratio": aspect_ratio,
+        "resolution": resolution,
+    }
+
+    if motion_prompt:
+        payload["motion_prompt"] = motion_prompt
+    if expressiveness:
+        payload["expressiveness"] = expressiveness
+    if remove_background:
+        payload["remove_background"] = True
+
+    resp = requests.post(
+        "https://api.heygen.com/v3/videos",
+        headers={
+            "X-Api-Key": api_key,
+            "Content-Type": "application/json",
+        },
+        json=payload,
+    )
+
+    data = resp.json()
+    if data.get("error"):
+        raise Exception(data["error"])
+
+    return data["data"]["video_id"]
+
+
+def poll_video_status(video_id: str) -> str:
+    api_key = os.environ["HEYGEN_API_KEY"]
+
+    for _ in range(120):
+        resp = requests.get(
+            f"https://api.heygen.com/v3/videos/{video_id}",
+            headers={"X-Api-Key": api_key},
+        )
+        data = resp.json()["data"]
+
+        if data["status"] == "completed":
+            return data["video_url"]
+        if data["status"] == "failed":
+            raise Exception(data.get("error", "Video generation failed"))
+
+        time.sleep(5)
+
+    raise Exception("Video generation timed out")
+
+
+# Usage
+video_id = create_photo_video(
+    image_url="https://example.com/portrait.jpg",
+    script="Hello! This is a high-quality photo avatar video.",
+    voice_id="1bd001e7e50f421d891986aad5158bc8",
+)
+video_url = poll_video_status(video_id)
+print(f"Video ready: {video_url}")
+```
+
+### Motion Prompts and Expressiveness
+
+Use `motion_prompt` and `expressiveness` to control how the photo avatar moves and emotes:
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "image",
+    "image": { "type": "url", "url": "https://example.com/portrait.jpg" },
+    "script": "Let me tell you about our exciting new product launch.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "motion_prompt": "nodding head and smiling, gesturing with hands while speaking",
+    "expressiveness": "high",
+    "aspect_ratio": "16:9"
+  }'
+```
+
+| Expressiveness | Description |
+|----------------|-------------|
+| `low` | Subtle, minimal movement (default) |
+| `medium` | Natural, moderate movement |
+| `high` | Energetic, pronounced movement |
+
+## Uploading Images
+
+If your image is not publicly accessible via URL, upload it first using the asset upload endpoint. Then use the returned asset ID with the `asset_id` variant of the `image` field.
+
+**Endpoint:** `POST https://upload.heygen.com/v1/asset`
 
 ```bash
 curl -X POST "https://upload.heygen.com/v1/asset" \
@@ -36,466 +287,29 @@ Response:
 }
 ```
 
-> **Important:** Save the `image_key` field (not the `id`). The `image_key` is the S3 path used to create the photo avatar.
+Then use the asset `id` in `POST /v3/videos`:
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "image",
+    "image": { "type": "asset_id", "asset_id": "741299e941764988b432ed3a6757878f" },
+    "script": "Hello from an uploaded photo!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8"
+  }'
+```
 
 See [assets.md](assets.md) for full upload details.
 
-### Step 2: Create Photo Avatar Group
-
-Use the `image_key` from the upload response to create a photo avatar group. This processes the image and creates a usable photo avatar.
-
-**Endpoint:** `POST https://api.heygen.com/v2/photo_avatar/avatar_group/create`
-
-```bash
-curl -X POST "https://api.heygen.com/v2/photo_avatar/avatar_group/create" \
-  -H "X-Api-Key: $HEYGEN_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "image_key": "image/741299e941764988b432ed3a6757878f/original.jpg",
-    "name": "My Photo Avatar"
-  }'
-```
-
-| Field | Type | Req | Description |
-|-------|------|:---:|-------------|
-| `image_key` | string | ✓ | S3 image key from upload response |
-| `name` | string | ✓ | Display name for the avatar |
-| `generation_id` | string | | If using AI-generated photo (see below) |
-
-Response:
-```json
-{
-  "error": null,
-  "data": {
-    "id": "045c260bc0364727b2cbe50442c3a5bf",
-    "image_url": "https://files2.heygen.ai/...",
-    "created_at": 1771798135.777256,
-    "name": "My Photo Avatar",
-    "status": "pending",
-    "group_id": "045c260bc0364727b2cbe50442c3a5bf",
-    "is_motion": false,
-    "business_type": "uploaded"
-  }
-}
-```
-
-The `id` (same as `group_id`) is your `talking_photo_id` for video generation.
-
-### Step 3: Wait for Processing
-
-The photo avatar starts with `status: "pending"` and transitions to `"completed"` within seconds. Poll the status endpoint:
-
-**Endpoint:** `GET https://api.heygen.com/v2/photo_avatar/{id}`
-
-```bash
-curl "https://api.heygen.com/v2/photo_avatar/045c260bc0364727b2cbe50442c3a5bf" \
-  -H "X-Api-Key: $HEYGEN_API_KEY"
-```
-
-Wait until `status` is `"completed"` before using in video generation.
-
-### Step 4: Use in Video Generation
-
-Use the photo avatar `id` as `talking_photo_id`:
-
-```typescript
-const videoConfig = {
-  video_inputs: [
-    {
-      character: {
-        type: "talking_photo",
-        talking_photo_id: "045c260bc0364727b2cbe50442c3a5bf",
-      },
-      voice: {
-        type: "text",
-        input_text: "Hello! This is my photo avatar speaking.",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-      },
-    },
-  ],
-  dimension: { width: 1920, height: 1080 },
-};
-```
-
-## TypeScript: Complete Workflow
-
-```typescript
-import fs from "fs";
-import path from "path";
-
-interface AssetUploadResponse {
-  code: number;
-  data: {
-    id: string;
-    image_key: string;
-    url: string;
-  };
-}
-
-interface PhotoAvatarResponse {
-  error: string | null;
-  data: {
-    id: string;
-    group_id: string;
-    image_url: string;
-    name: string;
-    status: string;
-    is_motion: boolean;
-    business_type: string;
-  };
-}
-
-async function createPhotoAvatar(
-  imagePath: string,
-  name: string
-): Promise<string> {
-  // 1. Upload image
-  const resolvedPath = path.resolve(imagePath);
-  const fileBuffer = fs.readFileSync(resolvedPath);
-  const uploadResponse = await fetch("https://upload.heygen.com/v1/asset", {
-    method: "POST",
-    headers: {
-      "X-Api-Key": process.env.HEYGEN_API_KEY!,
-      "Content-Type": "image/jpeg",
-    },
-    body: fileBuffer,
-  });
-
-  const uploadJson: AssetUploadResponse = await uploadResponse.json();
-  if (uploadJson.code !== 100) {
-    throw new Error("Upload failed");
-  }
-
-  const imageKey = uploadJson.data.image_key;
-
-  // 2. Create avatar group
-  const createResponse = await fetch(
-    "https://api.heygen.com/v2/photo_avatar/avatar_group/create",
-    {
-      method: "POST",
-      headers: {
-        "X-Api-Key": process.env.HEYGEN_API_KEY!,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ image_key: imageKey, name }),
-    }
-  );
-
-  const createJson: PhotoAvatarResponse = await createResponse.json();
-  if (createJson.error) {
-    throw new Error(createJson.error);
-  }
-
-  const photoAvatarId = createJson.data.id;
-
-  // 3. Wait for processing
-  await waitForPhotoAvatar(photoAvatarId);
-
-  return photoAvatarId;
-}
-
-async function waitForPhotoAvatar(id: string): Promise<void> {
-  for (let i = 0; i < 30; i++) {
-    const response = await fetch(
-      `https://api.heygen.com/v2/photo_avatar/${id}`,
-      { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
-    );
-
-    const json: PhotoAvatarResponse = await response.json();
-
-    if (json.data.status === "completed") return;
-    if (json.data.status === "failed") {
-      throw new Error("Photo avatar processing failed");
-    }
-
-    await new Promise((r) => setTimeout(r, 2000));
-  }
-
-  throw new Error("Photo avatar processing timed out");
-}
-
-async function createVideoFromPhoto(
-  photoPath: string,
-  script: string,
-  voiceId: string
-): Promise<string> {
-  // 1. Create photo avatar
-  const talkingPhotoId = await createPhotoAvatar(photoPath, "Video Avatar");
-
-  // 2. Generate video
-  const response = await fetch("https://api.heygen.com/v2/video/generate", {
-    method: "POST",
-    headers: {
-      "X-Api-Key": process.env.HEYGEN_API_KEY!,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      video_inputs: [
-        {
-          character: {
-            type: "talking_photo",
-            talking_photo_id: talkingPhotoId,
-          },
-          voice: {
-            type: "text",
-            input_text: script,
-            voice_id: voiceId,
-          },
-        },
-      ],
-      dimension: { width: 1920, height: 1080 },
-    }),
-  });
-
-  const { data } = await response.json();
-  return data.video_id;
-}
-```
-
-## Python: Complete Workflow
-
-```python
-import requests
-import os
-import time
-
-def create_photo_avatar(image_path: str, name: str) -> str:
-    api_key = os.environ["HEYGEN_API_KEY"]
-
-    # 1. Upload image
-    with open(image_path, "rb") as f:
-        upload_resp = requests.post(
-            "https://upload.heygen.com/v1/asset",
-            headers={
-                "X-Api-Key": api_key,
-                "Content-Type": "image/jpeg",
-            },
-            data=f,
-        )
-
-    upload_data = upload_resp.json()
-    if upload_data.get("code") != 100:
-        raise Exception("Upload failed")
-
-    image_key = upload_data["data"]["image_key"]
-
-    # 2. Create avatar group
-    create_resp = requests.post(
-        "https://api.heygen.com/v2/photo_avatar/avatar_group/create",
-        headers={
-            "X-Api-Key": api_key,
-            "Content-Type": "application/json",
-        },
-        json={"image_key": image_key, "name": name},
-    )
-
-    create_data = create_resp.json()
-    if create_data.get("error"):
-        raise Exception(create_data["error"])
-
-    photo_avatar_id = create_data["data"]["id"]
-
-    # 3. Wait for processing
-    for _ in range(30):
-        status_resp = requests.get(
-            f"https://api.heygen.com/v2/photo_avatar/{photo_avatar_id}",
-            headers={"X-Api-Key": api_key},
-        )
-        status = status_resp.json()["data"]["status"]
-        if status == "completed":
-            return photo_avatar_id
-        if status == "failed":
-            raise Exception("Photo avatar processing failed")
-        time.sleep(2)
-
-    raise Exception("Photo avatar processing timed out")
-```
-
-## Listing Existing Talking Photos
-
-Retrieve all talking photos in your account:
-
-**Endpoint:** `GET https://api.heygen.com/v1/talking_photo.list`
-
-```bash
-curl "https://api.heygen.com/v1/talking_photo.list" \
-  -H "X-Api-Key: $HEYGEN_API_KEY"
-```
-
-Response:
-```json
-{
-  "code": 100,
-  "data": [
-    {
-      "id": "ef0ed70f72c6497793e5e36e434d2aea",
-      "image_url": "https://files2.heygen.ai/talking_photo/.../image.WEBP",
-      "circle_image": ""
-    }
-  ]
-}
-```
-
-Each `id` can be used as `talking_photo_id` in video generation.
-
-## Adding Photos to an Existing Group
-
-Add additional photo looks to an existing avatar group:
-
-**Endpoint:** `POST https://api.heygen.com/v2/photo_avatar/avatar_group/add`
-
-```typescript
-async function addPhotosToGroup(
-  groupId: string,
-  imageKeys: string[],
-  name: string
-): Promise<void> {
-  const response = await fetch(
-    "https://api.heygen.com/v2/photo_avatar/avatar_group/add",
-    {
-      method: "POST",
-      headers: {
-        "X-Api-Key": process.env.HEYGEN_API_KEY!,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        group_id: groupId,
-        image_keys: imageKeys,
-        name,
-      }),
-    }
-  );
-
-  const json = await response.json();
-  if (json.error) {
-    throw new Error(json.error);
-  }
-}
-```
-
-## Training a Photo Avatar Group
-
-Train the avatar group for improved animation quality:
-
-**Endpoint:** `POST https://api.heygen.com/v2/photo_avatar/train`
-
-```bash
-curl -X POST "https://api.heygen.com/v2/photo_avatar/train" \
-  -H "X-Api-Key: $HEYGEN_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"group_id": "045c260bc0364727b2cbe50442c3a5bf"}'
-```
-
-Check training status:
-
-**Endpoint:** `GET https://api.heygen.com/v2/photo_avatar/train/status/{group_id}`
-
-## Avatar IV Video Generation
-
-Avatar IV is HeyGen's latest photo avatar technology with improved quality and natural motion. It generates a video directly from an uploaded image, bypassing the avatar group creation step.
-
-**Endpoint:** `POST https://api.heygen.com/v2/video/av4/generate`
-
-```bash
-curl -X POST "https://api.heygen.com/v2/video/av4/generate" \
-  -H "X-Api-Key: $HEYGEN_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "image_key": "image/741299e941764988b432ed3a6757878f/original.jpg",
-    "script": "Hello! This is Avatar IV with enhanced quality.",
-    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
-    "video_orientation": "landscape",
-    "video_title": "My Avatar IV Video"
-  }'
-```
-
-| Field | Type | Req | Description |
-|-------|------|:---:|-------------|
-| `image_key` | string | ✓ | S3 image key from asset upload |
-| `script` | string | ✓ | Text for the avatar to speak |
-| `voice_id` | string | ✓ | Voice to use |
-| `video_orientation` | string | | `"portrait"`, `"landscape"`, or `"square"` |
-| `video_title` | string | | Title for the video |
-| `fit` | string | | `"cover"` or `"contain"` |
-| `custom_motion_prompt` | string | | Motion/expression description |
-| `enhance_custom_motion_prompt` | boolean | | Enhance the motion prompt with AI |
-
-### TypeScript
-
-```typescript
-interface AvatarIVRequest {
-  image_key: string;
-  script: string;
-  voice_id: string;
-  video_orientation?: "portrait" | "landscape" | "square";
-  video_title?: string;
-  fit?: "cover" | "contain";
-  custom_motion_prompt?: string;
-  enhance_custom_motion_prompt?: boolean;
-}
-
-interface AvatarIVResponse {
-  error: null | string;
-  data: {
-    video_id: string;
-  };
-}
-
-async function generateAvatarIVVideo(
-  config: AvatarIVRequest
-): Promise<string> {
-  const response = await fetch(
-    "https://api.heygen.com/v2/video/av4/generate",
-    {
-      method: "POST",
-      headers: {
-        "X-Api-Key": process.env.HEYGEN_API_KEY!,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(config),
-    }
-  );
-
-  const json: AvatarIVResponse = await response.json();
-
-  if (json.error) {
-    throw new Error(json.error);
-  }
-
-  return json.data.video_id;
-}
-```
-
-### Avatar IV Options
-
-| Orientation | Dimensions | Use Case |
-|-------------|------------|----------|
-| `portrait` | 720x1280 | TikTok, Stories |
-| `landscape` | 1280x720 | YouTube, Web |
-| `square` | 720x720 | Instagram Feed |
-
-| Fit | Description |
-|-----|-------------|
-| `cover` | Fill the frame, may crop edges |
-| `contain` | Fit entire image, may show background |
-
-### Custom Motion Prompts
-
-```typescript
-const videoId = await generateAvatarIVVideo({
-  image_key: "image/.../original.jpg",
-  script: "Let me tell you about our product.",
-  voice_id: "1bd001e7e50f421d891986aad5158bc8",
-  custom_motion_prompt: "nodding head and smiling",
-  enhance_custom_motion_prompt: true,
-});
-```
-
-## Generating AI Photo Avatars
+## AI-Generated Photo Avatars
 
 Generate synthetic photo avatars from text descriptions instead of uploading a photo.
 
 **Endpoint:** `POST https://api.heygen.com/v2/photo_avatar/photo/generate`
+
+> **Note:** This endpoint is still v2 (no v3 equivalent). After generating an image, use the resulting image URL in `POST /v3/videos` with `"type": "image"` and `"image": { "type": "url", "url": "..." }` for high-quality video generation.
 
 > **IMPORTANT: All 8 fields are REQUIRED.** The API will reject requests missing any field.
 > When a user asks to "generate an AI avatar of a professional man", you need to ask for or select values for ALL fields below.
@@ -569,114 +383,14 @@ The response includes multiple generated images to choose from:
 }
 ```
 
-### TypeScript
+### AI Photo to Video (Recommended Flow)
 
-```typescript
-interface GeneratePhotoAvatarRequest {
-  name: string;
-  age: "Young Adult" | "Early Middle Age" | "Late Middle Age" | "Senior" | "Unspecified";
-  gender: "Woman" | "Man" | "Unspecified";
-  ethnicity: "White" | "Black" | "Asian American" | "East Asian" | "South East Asian" | "South Asian" | "Middle Eastern" | "Pacific" | "Hispanic" | "Unspecified";
-  orientation: "square" | "horizontal" | "vertical";
-  pose: "half_body" | "close_up" | "full_body";
-  style: "Realistic" | "Pixar" | "Cinematic" | "Vintage" | "Noir" | "Cyberpunk" | "Unspecified";
-  appearance: string;
-}
-
-interface GeneratePhotoAvatarResponse {
-  error: string | null;
-  data: {
-    generation_id: string;
-  };
-}
-
-interface PhotoGenerationStatus {
-  error: string | null;
-  data: {
-    id: string;
-    status: "pending" | "processing" | "success" | "failed";
-    msg: string | null;
-    image_url_list?: string[];
-    image_key_list?: string[];
-  };
-}
-
-async function generatePhotoAvatar(
-  config: GeneratePhotoAvatarRequest
-): Promise<string> {
-  const response = await fetch(
-    "https://api.heygen.com/v2/photo_avatar/photo/generate",
-    {
-      method: "POST",
-      headers: {
-        "X-Api-Key": process.env.HEYGEN_API_KEY!,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(config),
-    }
-  );
-
-  const json: GeneratePhotoAvatarResponse = await response.json();
-
-  if (json.error) {
-    throw new Error(`Photo avatar generation failed: ${json.error}`);
-  }
-
-  return json.data.generation_id;
-}
-
-async function waitForPhotoGeneration(
-  generationId: string
-): Promise<string[]> {
-  for (let i = 0; i < 60; i++) {
-    const response = await fetch(
-      `https://api.heygen.com/v2/photo_avatar/generation/${generationId}`,
-      { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
-    );
-
-    const json: PhotoGenerationStatus = await response.json();
-
-    if (json.error) throw new Error(json.error);
-
-    if (json.data.status === "success") {
-      return json.data.image_key_list!;
-    }
-
-    if (json.data.status === "failed") {
-      throw new Error(json.data.msg ?? "Photo generation failed");
-    }
-
-    await new Promise((r) => setTimeout(r, 5000));
-  }
-
-  throw new Error("Photo generation timed out");
-}
-```
-
-### AI Photo → Avatar Group → Video
-
-Use a generated AI photo to create an avatar group, then generate a video:
+Generate an AI photo, then use the resulting image URL directly in `POST /v3/videos`:
 
 ```typescript
 // 1. Generate AI photo
-const generationId = await generatePhotoAvatar({
-  name: "Product Demo Host",
-  age: "Young Adult",
-  gender: "Woman",
-  ethnicity: "Unspecified",
-  orientation: "horizontal",
-  pose: "half_body",
-  style: "Realistic",
-  appearance: "Professional woman, navy blazer, friendly smile, soft lighting",
-});
-
-// 2. Wait for generation and pick first result
-const imageKeys = await waitForPhotoGeneration(generationId);
-const selectedImageKey = imageKeys[0];
-
-// 3. Create avatar group from the AI photo
-const createResponse = await fetch(
-  "https://api.heygen.com/v2/photo_avatar/avatar_group/create",
+const genResponse = await fetch(
+  "https://api.heygen.com/v2/photo_avatar/photo/generate",
   {
     method: "POST",
     headers: {
@@ -684,31 +398,62 @@ const createResponse = await fetch(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      image_key: selectedImageKey,
       name: "Product Demo Host",
-      generation_id: generationId,
+      age: "Young Adult",
+      gender: "Woman",
+      ethnicity: "Unspecified",
+      orientation: "horizontal",
+      pose: "half_body",
+      style: "Realistic",
+      appearance:
+        "Professional woman, navy blazer, friendly smile, soft lighting",
     }),
   }
 );
 
-const { data } = await createResponse.json();
-const talkingPhotoId = data.id;
+const { data: genData } = await genResponse.json();
+const generationId = genData.generation_id;
 
-// 4. Generate video (after status is "completed")
-const videoId = await generateVideo({
-  video_inputs: [{
-    character: {
-      type: "talking_photo",
-      talking_photo_id: talkingPhotoId,
-    },
-    voice: {
-      type: "text",
-      input_text: "Welcome to our product demo!",
-      voice_id: "1bd001e7e50f421d891986aad5158bc8",
-    },
-  }],
-  dimension: { width: 1920, height: 1080 },
+// 2. Poll until generation completes
+let imageUrl: string | undefined;
+for (let i = 0; i < 60; i++) {
+  const statusResp = await fetch(
+    `https://api.heygen.com/v2/photo_avatar/generation/${generationId}`,
+    { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
+  );
+  const statusJson = await statusResp.json();
+
+  if (statusJson.data.status === "success") {
+    imageUrl = statusJson.data.image_url_list[0];
+    break;
+  }
+  if (statusJson.data.status === "failed") {
+    throw new Error("Photo generation failed");
+  }
+  await new Promise((r) => setTimeout(r, 5000));
+}
+
+if (!imageUrl) throw new Error("Photo generation timed out");
+
+// 3. Create video using v3 API with the generated image URL
+const videoResp = await fetch("https://api.heygen.com/v3/videos", {
+  method: "POST",
+  headers: {
+    "X-Api-Key": process.env.HEYGEN_API_KEY!,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    type: "image" as const,
+    image: { type: "url" as const, url: imageUrl },
+    script: "Welcome to our product demo!",
+    voice_id: "1bd001e7e50f421d891986aad5158bc8",
+    aspect_ratio: "16:9",
+    resolution: "1080p",
+  }),
 });
+
+const { data: videoData } = await videoResp.json();
+console.log("Video ID:", videoData.video_id);
 ```
 
 ### Pre-Generation Checklist
@@ -741,6 +486,99 @@ The `appearance` field is a text prompt - be descriptive:
 - Conflicting attributes
 - Requesting specific real people
 
+## Legacy: Creating Photo Avatar Groups
+
+> **Note:** This is the legacy workflow. For most use cases, prefer the direct `"type": "image"` approach with `POST /v3/videos` described above. The avatar group workflow is more complex and does not produce better results.
+
+The legacy workflow is: **Upload Image -> Create Avatar Group -> Use in Video**
+
+### Step 1: Upload the Image
+
+Upload a portrait photo using the asset upload endpoint (see [Uploading Images](#uploading-images) above).
+
+### Step 2: Create Photo Avatar Group
+
+Use the `image_key` from the upload response to create a photo avatar group.
+
+**Endpoint:** `POST https://api.heygen.com/v2/photo_avatar/avatar_group/create`
+
+```bash
+curl -X POST "https://api.heygen.com/v2/photo_avatar/avatar_group/create" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image_key": "image/741299e941764988b432ed3a6757878f/original.jpg",
+    "name": "My Photo Avatar"
+  }'
+```
+
+| Field | Type | Req | Description |
+|-------|------|:---:|-------------|
+| `image_key` | string | ✓ | S3 image key from upload response |
+| `name` | string | ✓ | Display name for the avatar |
+| `generation_id` | string | | If using AI-generated photo |
+
+Response:
+```json
+{
+  "error": null,
+  "data": {
+    "id": "045c260bc0364727b2cbe50442c3a5bf",
+    "image_url": "https://files2.heygen.ai/...",
+    "created_at": 1771798135.777256,
+    "name": "My Photo Avatar",
+    "status": "pending",
+    "group_id": "045c260bc0364727b2cbe50442c3a5bf",
+    "is_motion": false,
+    "business_type": "uploaded"
+  }
+}
+```
+
+### Step 3: Wait for Processing
+
+Poll `GET /v2/photo_avatar/{id}` until `status` is `"completed"`.
+
+### Step 4: Use in Video Generation
+
+Use the photo avatar look ID as `avatar_id` in `POST /v3/videos`:
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "045c260bc0364727b2cbe50442c3a5bf",
+    "script": "Hello! This is my photo avatar speaking.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "aspect_ratio": "16:9"
+  }'
+```
+
+### Adding Photos to an Existing Group
+
+**Endpoint:** `POST https://api.heygen.com/v2/photo_avatar/avatar_group/add`
+
+| Field | Type | Req | Description |
+|-------|------|:---:|-------------|
+| `group_id` | string | ✓ | Existing avatar group ID |
+| `image_keys` | string[] | ✓ | Array of S3 image keys |
+| `name` | string | ✓ | Name for the new looks |
+
+### Training a Photo Avatar Group
+
+**Endpoint:** `POST https://api.heygen.com/v2/photo_avatar/train`
+
+```bash
+curl -X POST "https://api.heygen.com/v2/photo_avatar/train" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"group_id": "045c260bc0364727b2cbe50442c3a5bf"}'
+```
+
+Check training status: `GET /v2/photo_avatar/train/status/{group_id}`
+
 ## Managing Photo Avatars
 
 ### Get Photo Avatar Details
@@ -748,7 +586,7 @@ The `appearance` field is a text prompt - be descriptive:
 **Endpoint:** `GET https://api.heygen.com/v2/photo_avatar/{id}`
 
 ```typescript
-async function getPhotoAvatar(id: string): Promise<PhotoAvatarResponse> {
+async function getPhotoAvatar(id: string): Promise<any> {
   const response = await fetch(
     `https://api.heygen.com/v2/photo_avatar/${id}`,
     { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
@@ -797,24 +635,6 @@ async function deletePhotoAvatarGroup(groupId: string): Promise<void> {
 }
 ```
 
-## API Reference
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `upload.heygen.com/v1/asset` | POST | Upload image (returns `image_key`) |
-| `/v2/photo_avatar/avatar_group/create` | POST | Create photo avatar from `image_key` |
-| `/v2/photo_avatar/avatar_group/add` | POST | Add photos to existing group |
-| `/v2/photo_avatar/train` | POST | Train avatar group |
-| `/v2/photo_avatar/train/status/{group_id}` | GET | Check training status |
-| `/v2/photo_avatar/{id}` | GET | Get photo avatar details/status |
-| `/v2/photo_avatar/{id}` | DELETE | Delete photo avatar |
-| `/v2/photo_avatar_group/{id}` | DELETE | Delete avatar group |
-| `/v2/photo_avatar/photo/generate` | POST | Generate AI photo from text |
-| `/v2/photo_avatar/generation/{id}` | GET | Check AI generation status |
-| `/v2/video/av4/generate` | POST | Avatar IV video from `image_key` |
-| `/v1/talking_photo.list` | GET | List all existing talking photos |
-| `/v2/video/generate` | POST | Generate video with `talking_photo_id` |
-
 ## Photo Requirements
 
 ### Technical Requirements
@@ -837,12 +657,30 @@ async function deletePhotoAvatarGroup(groupId: string): Promise<void> {
 
 ## Best Practices
 
-1. **Use high-quality photos** - Better input = better output
-2. **Front-facing portraits** - Work best for animation
-3. **Neutral expressions** - Allow for more natural animation
-4. **Use Avatar IV for best quality** - Latest generation technology
-5. **Train avatar groups** - Improves animation quality
-6. **Reuse photo avatar IDs** - Once created, use the same `talking_photo_id` across multiple videos
+1. **Use `POST /v3/videos` with `"type": "image"` for the best quality** - This is the recommended path and automatically uses Avatar IV technology
+2. **Use `"image": { "type": "asset_id", ... }` for private images** - Upload first via `POST upload.heygen.com/v1/asset`, then pass the asset ID in the `image` field
+3. **Use high-quality photos** - Better input = better output
+4. **Front-facing portraits work best** - Clear face visibility produces the most natural animation
+5. **Use `motion_prompt` for natural movement** - Describe the body language you want (e.g., "nodding and gesturing")
+6. **Start with `expressiveness: "low"`** - Increase to `"medium"` or `"high"` only if you want more energetic movement
+7. **Avoid the legacy avatar group workflow** - The direct `"type": "image"` approach is simpler and produces equivalent or better results
+
+## API Reference
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v3/videos` | POST | **Recommended** - Create video from photo with `"type": "image"` and nested `image` AssetInput |
+| `/v3/videos/{video_id}` | GET | Poll video generation status |
+| `upload.heygen.com/v1/asset` | POST | Upload image (returns asset `id` and `image_key`) |
+| `/v2/photo_avatar/photo/generate` | POST | Generate AI photo from text description |
+| `/v2/photo_avatar/generation/{id}` | GET | Check AI photo generation status |
+| `/v2/photo_avatar/{id}` | GET | Get photo avatar details/status |
+| `/v2/photo_avatar/{id}` | DELETE | Delete photo avatar |
+| `/v2/photo_avatar_group/{id}` | DELETE | Delete avatar group |
+| `/v2/photo_avatar/avatar_group/create` | POST | Legacy: Create photo avatar group from `image_key` |
+| `/v2/photo_avatar/avatar_group/add` | POST | Legacy: Add photos to existing group |
+| `/v2/photo_avatar/train` | POST | Legacy: Train avatar group |
+| `/v2/photo_avatar/train/status/{group_id}` | GET | Legacy: Check training status |
 
 ## Limitations
 

--- a/skills/avatar-video/references/remotion-integration.md
+++ b/skills/avatar-video/references/remotion-integration.md
@@ -93,32 +93,23 @@ async function generateHeyGenVideo(
 ): Promise<string> {
   const dimension = DIMENSIONS[preset];
 
-  const response = await fetch("https://api.heygen.com/v2/video/generate", {
+  const response = await fetch("https://api.heygen.com/v3/videos", {
     method: "POST",
     headers: {
       "X-Api-Key": process.env.HEYGEN_API_KEY!,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      video_inputs: [
-        {
-          character: {
-            type: "avatar",
-            avatar_id: avatarId,
-            avatar_style: "normal",
-          },
-          voice: {
-            type: "text",
-            input_text: script,
-            voice_id: voiceId,
-          },
-          background: {
-            type: "color",
-            value: "#00FF00", // Green screen for compositing
-          },
-        },
-      ],
-      dimension,
+      type: "avatar" as const,
+      avatar_id: avatarId,
+      script,
+      voice_id: voiceId,
+      background: {
+        type: "color",
+        value: "#00FF00", // Green screen for compositing
+      },
+      resolution: preset === "landscape_1080p" ? "1080p" : "720p",
+      aspect_ratio: preset.startsWith("portrait") ? "9:16" : "16:9",
     }),
   });
 
@@ -176,30 +167,23 @@ async function generateAvatarForRemotion(
 ): Promise<string> {
   const { style = "normal", backgroundColor = "#1a1a2e" } = options;
 
-  const response = await fetch("https://api.heygen.com/v2/video/generate", {
+  const response = await fetch("https://api.heygen.com/v3/videos", {
     method: "POST",
     headers: {
       "X-Api-Key": process.env.HEYGEN_API_KEY!,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      video_inputs: [{
-        character: {
-          type: "avatar",
-          avatar_id: avatarId,
-          avatar_style: style,
-        },
-        voice: {
-          type: "text",
-          input_text: script,
-          voice_id: voiceId,
-        },
-        background: {
-          type: "color",
-          value: backgroundColor,
-        },
-      }],
-      dimension: { width: 1920, height: 1080 },
+      type: "avatar" as const,
+      avatar_id: avatarId,
+      script,
+      voice_id: voiceId,
+      background: {
+        type: "color",
+        value: backgroundColor,
+      },
+      resolution: "1080p",
+      aspect_ratio: "16:9",
     }),
   });
 
@@ -213,20 +197,21 @@ async function generateAvatarForRemotion(
 Only use when you need to see content *behind* the avatar (e.g., avatar overlaid on screen recording):
 
 ```typescript
-// Use /v1/video.webm endpoint for transparent background
-// Note: Different structure than /v2/video/generate
-const response = await fetch("https://api.heygen.com/v1/video.webm", {
+// Use POST /v3/videos with remove_background: true for transparent background
+const response = await fetch("https://api.heygen.com/v3/videos", {
   method: "POST",
   headers: {
     "X-Api-Key": process.env.HEYGEN_API_KEY!,
     "Content-Type": "application/json",
   },
   body: JSON.stringify({
-    avatar_pose_id: avatarPoseId,  // Required: avatar pose ID
-    avatar_style: "normal",        // Required: "normal" or "closeUp" only
-    input_text: script,            // Required (with voice_id)
-    voice_id: voiceId,             // Required (with input_text)
-    dimension: { width: 1920, height: 1080 },
+    type: "avatar" as const,
+    avatar_id: avatarId,
+    script,
+    voice_id: voiceId,
+    remove_background: true,       // Transparent background
+    resolution: "1080p",
+    aspect_ratio: "16:9",
   }),
 });
 ```

--- a/skills/avatar-video/references/video-generation.md
+++ b/skills/avatar-video/references/video-generation.md
@@ -1,167 +1,173 @@
 ---
 name: video-generation
-description: POST /v2/video/generate workflow and multi-scene videos for HeyGen
+description: POST /v3/videos workflow for creating AI avatar videos with HeyGen
 ---
 
 # Video Generation
 
 ## Table of Contents
-- [Video Output Formats](#video-output-formats)
 - [Basic Video Generation](#basic-video-generation)
 - [Request Fields](#request-fields)
-- [Video Configuration Options](#video-configuration-options)
-- [Multi-Scene Videos](#multi-scene-videos)
-- [Using Different Character Types](#using-different-character-types)
-- [Voice Input Types](#voice-input-types)
+- [Type: Avatar](#type-avatar)
+- [Type: Image](#type-image)
+- [Voice Input Modes](#voice-input-modes)
+- [Voice Settings](#voice-settings)
+- [Motion and Expressiveness](#motion-and-expressiveness)
+- [Background Options](#background-options)
+- [Resolution and Aspect Ratio](#resolution-and-aspect-ratio)
 - [Complete Workflow Example](#complete-workflow-example)
 - [Error Handling](#error-handling)
 - [Script Length Limits](#script-length-limits)
 - [Adding Pauses to Scripts](#adding-pauses-to-scripts)
-- [Test Mode](#test-mode)
+- [Transparent Background](#transparent-background)
 - [Production-Ready Workflow](#production-ready-workflow)
-- [Transparent Background Videos (WebM)](#transparent-background-videos-webm)
 - [Best Practices](#best-practices)
 
 ---
 
-The `/v2/video/generate` endpoint is the primary way to create AI avatar videos with HeyGen.
+The `POST /v3/videos` endpoint creates AI avatar videos with HeyGen. The request body is a **discriminated union** on the `type` field with two variants:
 
-## Video Output Formats
+- **`type: "avatar"`** -- Use a HeyGen avatar (video or photo avatar) by its look ID.
+- **`type: "image"`** -- Animate an arbitrary image (via URL, asset ID, or base64). Uses Avatar IV automatically.
 
-| Endpoint | Format | Use Case |
-|----------|--------|----------|
-| `/v2/video/generate` | MP4 | **Standard** - videos with background (most common) |
-| `/v1/video.webm` | WebM | Transparent background - only when needed |
-
-Use MP4 with background for most cases. WebM is only needed when you want to see content *behind* the avatar (e.g., overlaying avatar on a screen recording).
+Each request produces a single video with one avatar/image and one voice input. For multi-scene workflows, create multiple videos and stitch them together in post-production.
 
 ## Basic Video Generation
 
-### curl
+### From a HeyGen avatar (`type: "avatar"`)
 
 ```bash
-curl -X POST "https://api.heygen.com/v2/video/generate" \
+curl -X POST "https://api.heygen.com/v3/videos" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "video_inputs": [
-      {
-        "character": {
-          "type": "avatar",
-          "avatar_id": "josh_lite3_20230714",
-          "avatar_style": "normal"
-        },
-        "voice": {
-          "type": "text",
-          "input_text": "Hello! Welcome to HeyGen.",
-          "voice_id": "1bd001e7e50f421d891986aad5158bc8"
-        }
-      }
-    ],
-    "dimension": {
-      "width": 1920,
-      "height": 1080
-    }
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "Hello! Welcome to HeyGen.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "resolution": "1080p",
+    "aspect_ratio": "16:9"
   }'
 ```
 
-## Request Fields
+### From an arbitrary image (`type: "image"`)
 
-### Top-Level Fields
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "image",
+    "image": {
+      "type": "url",
+      "url": "https://example.com/my-photo.jpg"
+    },
+    "script": "Hello from a custom image!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "resolution": "1080p",
+    "aspect_ratio": "16:9"
+  }'
+```
 
-| Field | Type | Req | Description |
-|-------|------|:---:|-------------|
-| `video_inputs` | array | ✓ | Array of 1-50 video input objects |
-| `dimension` | object | | Video dimensions `{width, height}` |
-| `title` | string | | Video name for organization |
-| `test` | boolean | | Test mode (watermarked, no credits) |
-| `caption` | boolean | | Enable auto-captions |
-| `callback_id` | string | | Custom ID for webhook tracking |
-| `callback_url` | string | | URL for completion notification |
-| `folder_id` | string | | Storage folder ID |
+### Response (same for both)
 
-### video_inputs[].character Fields
-
-| Field | Type | Req | Description |
-|-------|------|:---:|-------------|
-| `type` | string | ✓ | `"avatar"` or `"talking_photo"` |
-| `avatar_id` | string | ✓* | Avatar ID (*required when type is "avatar") |
-| `talking_photo_id` | string | ✓* | Photo ID (*required when type is "talking_photo") |
-| `avatar_style` | string | | `"normal"`, `"closeUp"`, or `"circle"` |
-| `scale` | number | | Avatar scale factor |
-| `offset` | object | | Position offset `{x, y}` |
-
-### video_inputs[].voice Fields
-
-| Field | Type | Req | Description |
-|-------|------|:---:|-------------|
-| `type` | string | ✓ | `"text"`, `"audio"`, or `"silence"` |
-| `voice_id` | string | ✓* | Voice ID (*required when type is "text") |
-| `input_text` | string | ✓* | Script text (*required when type is "text") |
-| `audio_url` | string | ✓* | Audio URL (*required when type is "audio") |
-| `duration` | number | ✓* | Duration in seconds (*required when type is "silence") |
-| `speed` | number | | Speech speed 0.5-2.0 (default 1.0) |
-| `pitch` | number | | Voice pitch -20 to 20 (default 0) |
-
-### video_inputs[].background Fields
-
-| Field | Type | Req | Description |
-|-------|------|:---:|-------------|
-| `type` | string | | `"color"`, `"image"`, or `"video"` |
-| `value` | string | | Hex color (when type is "color") |
-| `url` | string | | Image/video URL (when type is "image"/"video") |
-| `fit` | string | | `"cover"` or `"contain"` |
+```json
+{
+  "data": {
+    "video_id": "abc123",
+    "status": "waiting"
+  }
+}
+```
 
 ### TypeScript
 
 ```typescript
-// Required fields have no '?' - optional fields have '?'
-interface VideoInput {
-  character: {
-    type: "avatar" | "talking_photo";           // Required
-    avatar_id?: string;                         // Required when type="avatar"
-    talking_photo_id?: string;                  // Required when type="talking_photo"
-    avatar_style?: "normal" | "closeUp" | "circle";
-    scale?: number;
-    offset?: { x: number; y: number };
-  };
-  voice: {
-    type: "text" | "audio" | "silence";         // Required
-    input_text?: string;                        // Required when type="text"
-    voice_id?: string;                          // Required when type="text"
-    audio_url?: string;                         // Required when type="audio"
-    duration?: number;                          // Required when type="silence"
-    speed?: number;
-    pitch?: number;
-  };
-  background?: {
-    type?: "color" | "image" | "video";
-    value?: string;
-    url?: string;
-    fit?: "cover" | "contain";
-  };
+// Discriminated union: the `type` field determines which variant is used.
+
+interface AssetInputUrl {
+  type: "url";
+  url: string;
 }
 
-interface VideoGenerateRequest {
-  video_inputs: VideoInput[];                   // Required
-  dimension?: { width: number; height: number };
-  test?: boolean;
+interface AssetInputAssetId {
+  type: "asset_id";
+  asset_id: string;
+}
+
+interface AssetInputBase64 {
+  type: "base64";
+  media_type: string;  // e.g. "image/png"
+  data: string;
+}
+
+type AssetInput = AssetInputUrl | AssetInputAssetId | AssetInputBase64;
+
+interface SharedVideoFields {
+  // Voice source (mutually exclusive groups)
+  script?: string;          // Text script -- requires voice_id
+  voice_id?: string;        // Voice ID for TTS -- required with script
+  audio_url?: string;       // Public URL of audio to lip-sync
+  audio_asset_id?: string;  // HeyGen asset ID of uploaded audio
+
+  // Display
   title?: string;
-  caption?: boolean;
-  callback_id?: string;
+  resolution?: "1080p" | "720p";
+  aspect_ratio?: "16:9" | "9:16";
+
+  // Avatar behavior (photo avatars / image mode)
+  motion_prompt?: string;
+  expressiveness?: "high" | "medium" | "low";
+
+  // Background
+  remove_background?: boolean;
+  background?: {
+    type: "color" | "image";
+    value?: string;     // Hex color (when type is "color")
+    url?: string;       // Image URL (when type is "image")
+    asset_id?: string;  // HeyGen asset ID (when type is "image")
+  };
+
+  // Voice tuning
+  voice_settings?: {
+    speed?: number;   // 0.5 - 1.5
+    pitch?: number;   // -50 to 50
+    locale?: string;  // e.g. "en-US"
+  };
+
+  // Callbacks
   callback_url?: string;
-  folder_id?: string;
+  callback_id?: string;
 }
 
-interface VideoGenerateResponse {
-  error: null | string;
+interface CreateVideoFromAvatar extends SharedVideoFields {
+  type: "avatar";
+  avatar_id: string;       // Required: HeyGen avatar look ID
+}
+
+interface CreateVideoFromImage extends SharedVideoFields {
+  type: "image";
+  image: AssetInput;       // Required: image source (url, asset_id, or base64)
+}
+
+type CreateVideoRequest = CreateVideoFromAvatar | CreateVideoFromImage;
+
+interface CreateVideoResponse {
   data: {
     video_id: string;
+    status: string; // e.g. "waiting"
   };
 }
 
-async function generateVideo(config: VideoGenerateRequest): Promise<string> {
-  const response = await fetch("https://api.heygen.com/v2/video/generate", {
+interface VideoErrorResponse {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+async function generateVideo(config: CreateVideoRequest): Promise<string> {
+  const response = await fetch("https://api.heygen.com/v3/videos", {
     method: "POST",
     headers: {
       "X-Api-Key": process.env.HEYGEN_API_KEY!,
@@ -170,13 +176,15 @@ async function generateVideo(config: VideoGenerateRequest): Promise<string> {
     body: JSON.stringify(config),
   });
 
-  const json: VideoGenerateResponse = await response.json();
+  const json = await response.json();
 
-  if (json.error) {
-    throw new Error(json.error);
+  if (!response.ok) {
+    const err = json as VideoErrorResponse;
+    throw new Error(`${err.error.code}: ${err.error.message}`);
   }
 
-  return json.data.video_id;
+  const result = json as CreateVideoResponse;
+  return result.data.video_id;
 }
 ```
 
@@ -188,209 +196,722 @@ import os
 
 def generate_video(config: dict) -> str:
     response = requests.post(
-        "https://api.heygen.com/v2/video/generate",
+        "https://api.heygen.com/v3/videos",
         headers={
             "X-Api-Key": os.environ["HEYGEN_API_KEY"],
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         },
-        json=config
+        json=config,
     )
 
     data = response.json()
-    if data.get("error"):
-        raise Exception(data["error"])
+    if not response.ok:
+        err = data["error"]
+        raise Exception(f"{err['code']}: {err['message']}")
 
     return data["data"]["video_id"]
 ```
 
-## Video Configuration Options
+## Request Fields
 
-### Full Configuration Example
+The v3 API uses a **discriminated union** on the `type` field. The `type` determines which variant-specific fields are required, while audio, display, and output fields are shared across both variants.
+
+### Discriminator
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"avatar"` \| `"image"` | **Required.** Selects the creation mode. |
+
+### Type-specific Fields
+
+| Field | Applies to | Type | Description |
+|-------|-----------|------|-------------|
+| `avatar_id` | `type: "avatar"` | string | **Required.** HeyGen avatar look ID. |
+| `image` | `type: "image"` | AssetInput | **Required.** Image source as a discriminated union (see [Type: Image](#type-image)). |
+
+### Shared Audio Fields (mutually exclusive groups)
+
+Provide exactly one audio source: `script` + `voice_id`, or `audio_url`, or `audio_asset_id`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `script` | string \| null | Text script for the avatar to speak. Requires `voice_id`. |
+| `voice_id` | string \| null | Voice ID for TTS. Required when `script` is provided. |
+| `audio_url` | string \| null | Public URL of audio file to lip-sync. Mutually exclusive with `script`. |
+| `audio_asset_id` | string \| null | HeyGen asset ID of uploaded audio. Mutually exclusive with `script`. |
+
+### Shared Output Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | string \| null | Display title in HeyGen dashboard. |
+| `resolution` | `"1080p"` \| `"720p"` \| null | Output resolution. |
+| `aspect_ratio` | `"16:9"` \| `"9:16"` \| null | Output aspect ratio. |
+| `motion_prompt` | string \| null | Natural-language prompt controlling body motion. Photo avatars and image mode. |
+| `expressiveness` | `"high"` \| `"medium"` \| `"low"` \| null | Expression intensity. Photo avatars and image mode. Defaults to `"low"`. |
+| `remove_background` | boolean \| null | Remove the avatar background. |
+| `background` | object \| null | Background config (see [Background Options](#background-options)). |
+| `voice_settings` | object \| null | Voice tuning (see [Voice Settings](#voice-settings)). |
+| `callback_url` | string \| null | URL for completion webhook notification. |
+| `callback_id` | string \| null | Custom ID included in webhook payload. |
+
+## Type: Avatar
+
+Use `type: "avatar"` to create a video from a HeyGen avatar (video or photo avatar) by its look ID. The `avatar_id` field is required.
+
+### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "Hello from a HeyGen avatar!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8"
+  }'
+```
+
+### TypeScript
 
 ```typescript
-const fullConfig: VideoGenerateRequest = {
-  // Test mode (no credits consumed, watermarked output)
-  test: false,
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "Hello from a HeyGen avatar!",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+});
+```
 
-  // Video title (for organization)
-  title: "Product Demo Video",
+### Python
 
-  // Video dimensions
-  dimension: {
-    width: 1920,
-    height: 1080,
+```python
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "Hello from a HeyGen avatar!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+})
+```
+
+## Type: Image
+
+Use `type: "image"` to animate an arbitrary image. The `image` field is required and is itself a discriminated union (`AssetInput`) with three variants:
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `type: "url"` | `url` (string, required) | Public URL of the image. |
+| `type: "asset_id"` | `asset_id` (string, required) | HeyGen asset ID from a previous upload. |
+| `type: "base64"` | `media_type` (string, required), `data` (string, required) | Inline base64-encoded image. |
+
+### 1. Image from URL
+
+#### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "image",
+    "image": {
+      "type": "url",
+      "url": "https://example.com/my-photo.jpg"
+    },
+    "script": "Hello from a custom image!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8"
+  }'
+```
+
+#### TypeScript
+
+```typescript
+const videoId = await generateVideo({
+  type: "image",
+  image: {
+    type: "url",
+    url: "https://example.com/my-photo.jpg",
   },
+  script: "Hello from a custom image!",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+});
+```
 
-  // Video scenes/inputs
-  video_inputs: [
-    {
-      // Avatar configuration
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
+#### Python
 
-      // Voice configuration
-      voice: {
-        type: "text",
-        input_text: "Welcome to our product demonstration!",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-        speed: 1.0,
-        pitch: 0,
-      },
-
-      // Background configuration
-      background: {
-        type: "color",
-        value: "#FFFFFF",
-      },
+```python
+video_id = generate_video({
+    "type": "image",
+    "image": {
+        "type": "url",
+        "url": "https://example.com/my-photo.jpg",
     },
-  ],
-};
+    "script": "Hello from a custom image!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+})
 ```
 
-## Multi-Scene Videos
+### 2. Image from Asset ID
 
-Create videos with multiple scenes:
+#### curl
 
-```typescript
-const multiSceneConfig = {
-  video_inputs: [
-    // Scene 1: Introduction
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: "Hello! Today I'll show you three key features.",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-      },
-      background: {
-        type: "color",
-        value: "#1a1a2e",
-      },
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "image",
+    "image": {
+      "type": "asset_id",
+      "asset_id": "asset_abc123"
     },
-    // Scene 2: Feature 1
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "closeUp",
-      },
-      voice: {
-        type: "text",
-        input_text: "First, let's look at our dashboard.",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-      },
-      background: {
-        type: "image",
-        url: "https://example.com/dashboard-bg.jpg",
-      },
+    "script": "Hello from an uploaded image!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8"
+  }'
+```
+
+#### TypeScript
+
+```typescript
+const videoId = await generateVideo({
+  type: "image",
+  image: {
+    type: "asset_id",
+    asset_id: "asset_abc123",
+  },
+  script: "Hello from an uploaded image!",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+});
+```
+
+#### Python
+
+```python
+video_id = generate_video({
+    "type": "image",
+    "image": {
+        "type": "asset_id",
+        "asset_id": "asset_abc123",
     },
-    // Scene 3: Conclusion
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: "Thanks for watching! Try it today.",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-      },
-      background: {
-        type: "color",
-        value: "#1a1a2e",
-      },
+    "script": "Hello from an uploaded image!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+})
+```
+
+### 3. Image from Base64
+
+#### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "image",
+    "image": {
+      "type": "base64",
+      "media_type": "image/png",
+      "data": "iVBORw0KGgoAAAANSUhEUgAA..."
     },
-  ],
-  dimension: { width: 1920, height: 1080 },
-};
+    "script": "Hello from a base64 image!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8"
+  }'
 ```
 
-## Using Different Character Types
-
-### Avatar
+#### TypeScript
 
 ```typescript
-{
-  character: {
-    type: "avatar",
-    avatar_id: "josh_lite3_20230714",
-    avatar_style: "normal"
-  }
-}
+import { readFileSync } from "fs";
+
+const imageData = readFileSync("photo.png").toString("base64");
+
+const videoId = await generateVideo({
+  type: "image",
+  image: {
+    type: "base64",
+    media_type: "image/png",
+    data: imageData,
+  },
+  script: "Hello from a base64 image!",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+});
 ```
 
-### Talking Photo
+#### Python
 
-```typescript
-{
-  character: {
-    type: "talking_photo",
-    talking_photo_id: "your_talking_photo_id"
-  }
-}
+```python
+import base64
+
+with open("photo.png", "rb") as f:
+    image_data = base64.b64encode(f.read()).decode("utf-8")
+
+video_id = generate_video({
+    "type": "image",
+    "image": {
+        "type": "base64",
+        "media_type": "image/png",
+        "data": image_data,
+    },
+    "script": "Hello from a base64 image!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+})
 ```
 
-## Voice Input Types
+## Voice Input Modes
 
-### Text-to-Speech
+There are three mutually exclusive ways to provide voice input. These work the same for both `type: "avatar"` and `type: "image"`.
 
-```typescript
-{
-  voice: {
-    type: "text",
-    input_text: "Your script here",
-    voice_id: "1bd001e7e50f421d891986aad5158bc8",
-    speed: 1.0,  // 0.5 - 2.0
-    pitch: 0     // -20 to 20
-  }
-}
+### 1. Text-to-Speech (`script` + `voice_id`)
+
+Provide a text script and a voice ID. HeyGen generates speech and lip-syncs the avatar.
+
+#### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "This is text-to-speech with a chosen voice.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "voice_settings": {
+      "speed": 1.1,
+      "pitch": 5
+    }
+  }'
 ```
 
-### Custom Audio
+#### TypeScript
 
 ```typescript
-{
-  voice: {
-    type: "audio",
-    audio_url: "https://example.com/your-audio.mp3"
-  }
-}
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "This is text-to-speech with a chosen voice.",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  voice_settings: {
+    speed: 1.1,
+    pitch: 5,
+  },
+});
+```
+
+#### Python
+
+```python
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "This is text-to-speech with a chosen voice.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "voice_settings": {
+        "speed": 1.1,
+        "pitch": 5,
+    },
+})
+```
+
+### 2. Custom Audio (`audio_url`)
+
+Provide a pre-recorded audio file by URL. The avatar lip-syncs to it. Do not provide `script` or `voice_id` when using audio input.
+
+#### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "audio_url": "https://example.com/narration.mp3"
+  }'
+```
+
+#### TypeScript
+
+```typescript
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  audio_url: "https://example.com/narration.mp3",
+});
+```
+
+#### Python
+
+```python
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "audio_url": "https://example.com/narration.mp3",
+})
+```
+
+### 3. Uploaded Audio Asset (`audio_asset_id`)
+
+Use an audio file previously uploaded to HeyGen's asset system.
+
+#### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "audio_asset_id": "asset_audio_456"
+  }'
+```
+
+#### TypeScript
+
+```typescript
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  audio_asset_id: "asset_audio_456",
+});
+```
+
+#### Python
+
+```python
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "audio_asset_id": "asset_audio_456",
+})
+```
+
+## Voice Settings
+
+Fine-tune TTS output with `voice_settings`. Only applicable when using `script` + `voice_id`.
+
+| Field | Type | Range | Description |
+|-------|------|-------|-------------|
+| `speed` | number | 0.5 - 1.5 | Speech speed multiplier. Default 1.0. |
+| `pitch` | number | -50 to 50 | Voice pitch adjustment. Default 0. |
+| `locale` | string | | Language locale hint (e.g. `"en-US"`, `"es-ES"`). |
+
+### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "This has custom voice settings.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "voice_settings": {
+      "speed": 0.9,
+      "pitch": -10,
+      "locale": "en-US"
+    }
+  }'
+```
+
+### TypeScript
+
+```typescript
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "This has custom voice settings.",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  voice_settings: {
+    speed: 0.9,
+    pitch: -10,
+    locale: "en-US",
+  },
+});
+```
+
+### Python
+
+```python
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "This has custom voice settings.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "voice_settings": {
+        "speed": 0.9,
+        "pitch": -10,
+        "locale": "en-US",
+    },
+})
+```
+
+## Motion and Expressiveness
+
+Control avatar body motion and facial expressiveness. These work with **photo avatars** (`type: "avatar"`) and **image mode** (`type: "image"`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `motion_prompt` | string | Natural-language description of desired body motion (e.g. `"lean forward enthusiastically"`, `"nod while speaking"`). |
+| `expressiveness` | `"high"` \| `"medium"` \| `"low"` | Facial expression intensity. Defaults to `"low"`. |
+
+### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "I am really excited to show you this feature!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "motion_prompt": "lean forward with enthusiasm, use hand gestures",
+    "expressiveness": "high"
+  }'
+```
+
+### TypeScript
+
+```typescript
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "I am really excited to show you this feature!",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  motion_prompt: "lean forward with enthusiasm, use hand gestures",
+  expressiveness: "high",
+});
+```
+
+### Python
+
+```python
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "I am really excited to show you this feature!",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "motion_prompt": "lean forward with enthusiasm, use hand gestures",
+    "expressiveness": "high",
+})
+```
+
+## Background Options
+
+Set a custom background with the `background` field.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"color"` \| `"image"` | Background type. |
+| `value` | string | Hex color code (when type is `"color"`). |
+| `url` | string | Public image URL (when type is `"image"`). |
+| `asset_id` | string | HeyGen asset ID of uploaded image (when type is `"image"`). |
+
+### Solid Color Background
+
+#### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "White background video.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "background": {
+      "type": "color",
+      "value": "#FFFFFF"
+    }
+  }'
+```
+
+#### TypeScript
+
+```typescript
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "White background video.",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  background: {
+    type: "color",
+    value: "#FFFFFF",
+  },
+});
+```
+
+#### Python
+
+```python
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "White background video.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "background": {
+        "type": "color",
+        "value": "#FFFFFF",
+    },
+})
+```
+
+### Image Background
+
+#### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "Custom image background.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "background": {
+      "type": "image",
+      "url": "https://example.com/office-bg.jpg"
+    }
+  }'
+```
+
+#### TypeScript
+
+```typescript
+// Using a public URL
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "Custom image background.",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  background: {
+    type: "image",
+    url: "https://example.com/office-bg.jpg",
+  },
+});
+
+// Using a HeyGen asset
+const videoId2 = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "Background from uploaded asset.",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  background: {
+    type: "image",
+    asset_id: "asset_bg_789",
+  },
+});
+```
+
+#### Python
+
+```python
+# Using a public URL
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "Custom image background.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "background": {
+        "type": "image",
+        "url": "https://example.com/office-bg.jpg",
+    },
+})
+
+# Using a HeyGen asset
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "Background from uploaded asset.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "background": {
+        "type": "image",
+        "asset_id": "asset_bg_789",
+    },
+})
+```
+
+## Resolution and Aspect Ratio
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `resolution` | `"1080p"`, `"720p"` | Output resolution. Defaults to `"1080p"`. |
+| `aspect_ratio` | `"16:9"`, `"9:16"` | Output aspect ratio. `"16:9"` for landscape, `"9:16"` for portrait/mobile. |
+
+### curl
+
+```bash
+# Portrait/mobile video
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "This is a portrait video for mobile.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "resolution": "1080p",
+    "aspect_ratio": "9:16"
+  }'
+```
+
+### TypeScript
+
+```typescript
+// Portrait/mobile video
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "This is a portrait video for mobile.",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  resolution: "1080p",
+  aspect_ratio: "9:16",
+});
+```
+
+### Python
+
+```python
+# Portrait/mobile video
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "This is a portrait video for mobile.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "resolution": "1080p",
+    "aspect_ratio": "9:16",
+})
 ```
 
 ## Complete Workflow Example
 
+### TypeScript
+
 ```typescript
-async function createVideo(script: string, avatarId: string, voiceId: string) {
+async function createVideo(
+  script: string,
+  avatarId: string,
+  voiceId: string
+): Promise<string> {
   // 1. Generate video
   console.log("Starting video generation...");
   const videoId = await generateVideo({
-    video_inputs: [
-      {
-        character: {
-          type: "avatar",
-          avatar_id: avatarId,
-          avatar_style: "normal",
-        },
-        voice: {
-          type: "text",
-          input_text: script,
-          voice_id: voiceId,
-        },
-        background: {
-          type: "color",
-          value: "#FFFFFF",
-        },
-      },
-    ],
-    dimension: { width: 1920, height: 1080 },
+    type: "avatar",
+    avatar_id: avatarId,
+    script: script,
+    voice_id: voiceId,
+    resolution: "1080p",
+    aspect_ratio: "16:9",
+    background: {
+      type: "color",
+      value: "#FFFFFF",
+    },
   });
 
   console.log(`Video ID: ${videoId}`);
@@ -410,11 +931,18 @@ async function waitForVideo(videoId: string): Promise<string> {
 
   for (let i = 0; i < maxAttempts; i++) {
     const response = await fetch(
-      `https://api.heygen.com/v2/videos/${videoId}`,
+      `https://api.heygen.com/v3/videos/${videoId}`,
       { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
     );
 
-    const { data } = await response.json();
+    const json = await response.json();
+
+    if (!response.ok) {
+      const err = json as VideoErrorResponse;
+      throw new Error(`${err.error.code}: ${err.error.message}`);
+    }
+
+    const { data } = json;
 
     if (data.status === "completed") {
       return data.video_url;
@@ -429,28 +957,124 @@ async function waitForVideo(videoId: string): Promise<string> {
 }
 ```
 
+### Python
+
+```python
+import time
+
+def create_video(script: str, avatar_id: str, voice_id: str) -> str:
+    # 1. Generate video
+    print("Starting video generation...")
+    video_id = generate_video({
+        "type": "avatar",
+        "avatar_id": avatar_id,
+        "script": script,
+        "voice_id": voice_id,
+        "resolution": "1080p",
+        "aspect_ratio": "16:9",
+        "background": {
+            "type": "color",
+            "value": "#FFFFFF",
+        },
+    })
+
+    print(f"Video ID: {video_id}")
+
+    # 2. Poll for completion
+    print("Waiting for video completion...")
+    video_url = wait_for_video(video_id)
+
+    print(f"Video ready: {video_url}")
+    return video_url
+
+
+def wait_for_video(video_id: str, max_attempts: int = 60, poll_interval: int = 10) -> str:
+    for _ in range(max_attempts):
+        response = requests.get(
+            f"https://api.heygen.com/v3/videos/{video_id}",
+            headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        )
+
+        data = response.json()
+        if not response.ok:
+            err = data["error"]
+            raise Exception(f"{err['code']}: {err['message']}")
+
+        status = data["data"]["status"]
+
+        if status == "completed":
+            return data["data"]["video_url"]
+        elif status == "failed":
+            raise Exception(data["data"].get("failure_message", "Video generation failed"))
+
+        time.sleep(poll_interval)
+
+    raise Exception("Video generation timed out")
+```
+
 ## Error Handling
 
+The v3 API returns errors in a structured format:
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "avatar_id is required when type is avatar"
+  }
+}
+```
+
+### TypeScript
+
 ```typescript
-async function generateVideoSafe(config: VideoGenerateRequest) {
+async function generateVideoSafe(config: CreateVideoRequest) {
   try {
     const videoId = await generateVideo(config);
     return { success: true, videoId };
   } catch (error) {
-    // Common errors
-    if (error.message.includes("quota")) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // Common error patterns
+    if (message.includes("quota") || message.includes("credit")) {
       console.error("Insufficient credits");
-    } else if (error.message.includes("avatar")) {
+    } else if (message.includes("avatar")) {
       console.error("Invalid avatar ID");
-    } else if (error.message.includes("voice")) {
+    } else if (message.includes("voice")) {
       console.error("Invalid voice ID");
-    } else if (error.message.includes("script")) {
+    } else if (message.includes("image")) {
+      console.error("Invalid image input");
+    } else if (message.includes("script")) {
       console.error("Script too long or invalid");
     }
 
-    return { success: false, error: error.message };
+    return { success: false, error: message };
   }
 }
+```
+
+### Python
+
+```python
+def generate_video_safe(config: dict) -> dict:
+    try:
+        video_id = generate_video(config)
+        return {"success": True, "video_id": video_id}
+    except Exception as e:
+        message = str(e)
+
+        if "quota" in message or "credit" in message:
+            print("Insufficient credits")
+        elif "avatar" in message:
+            print("Invalid avatar ID")
+        elif "voice" in message:
+            print("Invalid voice ID")
+        elif "image" in message:
+            print("Invalid image input")
+        elif "script" in message:
+            print("Script too long or invalid")
+
+        return {"success": False, "error": message}
 ```
 
 ## Script Length Limits
@@ -467,7 +1091,7 @@ async function generateVideoSafe(config: VideoGenerateRequest) {
 Use `<break>` tags to add pauses in your script:
 
 ```typescript
-const script = "Welcome to our demo. <break time=\"1s\"/> Let me show you the features.";
+const script = 'Welcome to our demo. <break time="1s"/> Let me show you the features.';
 ```
 
 **Format:** `<break time="Xs"/>` where X is seconds (e.g., `1s`, `1.5s`, `0.5s`)
@@ -476,20 +1100,63 @@ const script = "Welcome to our demo. <break time=\"1s\"/> Let me show you the fe
 
 See [voices.md](voices.md) for detailed break tag documentation.
 
-## Test Mode
+## Transparent Background
 
-Use test mode during development:
+Use `remove_background: true` to generate a video with the avatar's background removed. This is useful when you want to overlay the avatar on other content in post-production.
+
+### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "This video has the background removed.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "remove_background": true
+  }'
+```
+
+### TypeScript
 
 ```typescript
-const config = {
-  test: true, // Watermarked output, no credits consumed
-  video_inputs: [...],
-};
+const videoId = await generateVideo({
+  type: "avatar",
+  avatar_id: "josh_lite3_20230714",
+  script: "This video has the background removed.",
+  voice_id: "1bd001e7e50f421d891986aad5158bc8",
+  remove_background: true,
+});
 ```
+
+### Python
+
+```python
+video_id = generate_video({
+    "type": "avatar",
+    "avatar_id": "josh_lite3_20230714",
+    "script": "This video has the background removed.",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "remove_background": True,
+})
+```
+
+**When to use `remove_background`:**
+- Avatar overlaid on screen recordings (Loom-style)
+- Avatar floating over video or image content
+- True alpha-channel compositing in post-production
+
+**When you do NOT need `remove_background`:**
+- Avatar with overlays/text on top of the avatar
+- Standard presenter videos with a solid or image background
 
 ## Production-Ready Workflow
 
-Complete example using avatar's default voice (recommended), proper timeouts, and retry logic:
+Complete example using the avatar's default voice (recommended), proper timeouts, and retry logic.
+
+### TypeScript
 
 ```typescript
 interface VideoGenerationResult {
@@ -505,84 +1172,112 @@ async function generateAvatarVideo(
   script: string,
   options: {
     avatarId?: string; // Specific avatar, or will pick first available
-    width?: number;
-    height?: number;
+    resolution?: "1080p" | "720p";
+    aspectRatio?: "16:9" | "9:16";
   } = {}
 ): Promise<VideoGenerationResult> {
-  const { width = 1920, height = 1080 } = options;
+  const { resolution = "1080p", aspectRatio = "16:9" } = options;
   let { avatarId } = options;
 
-  // 1. List avatars if no specific one provided
+  // 1. List avatar looks if no specific one provided
   if (!avatarId) {
-    console.log("Listing available avatars...");
-    const listResponse = await fetch("https://api.heygen.com/v2/avatars", {
+    console.log("Listing available avatar looks...");
+    const listResponse = await fetch("https://api.heygen.com/v3/avatars/looks", {
       headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
     });
+
+    if (!listResponse.ok) {
+      const err = await listResponse.json();
+      throw new Error(`${err.error.code}: ${err.error.message}`);
+    }
+
     const listData = await listResponse.json();
 
-    if (!listData.data?.avatars?.length) {
-      throw new Error("No avatars available");
+    if (!listData.data?.length) {
+      throw new Error("No avatar looks available");
     }
-    avatarId = listData.data.avatars[0].avatar_id;
+    avatarId = listData.data[0].id;
   }
 
-  // 2. Get avatar details including default_voice_id
-  console.log(`Getting details for avatar: ${avatarId}`);
+  // 2. Get avatar look details including default voice
+  console.log(`Getting details for avatar look: ${avatarId}`);
   const detailsResponse = await fetch(
-    `https://api.heygen.com/v2/avatar/${avatarId}/details`,
+    `https://api.heygen.com/v3/avatars/looks/${avatarId}`,
     { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
   );
+
+  if (!detailsResponse.ok) {
+    const err = await detailsResponse.json();
+    throw new Error(`${err.error.code}: ${err.error.message}`);
+  }
+
   const { data: avatar } = await detailsResponse.json();
 
   if (!avatar.default_voice_id) {
-    throw new Error(`Avatar ${avatar.name} has no default voice - select voice manually`);
+    throw new Error(
+      `Avatar ${avatar.name} has no default voice - select a voice manually`
+    );
   }
 
-  console.log(`Using avatar: ${avatar.name} with default voice: ${avatar.default_voice_id}`);
+  console.log(
+    `Using avatar: ${avatar.name} with default voice: ${avatar.default_voice_id}`
+  );
 
-  // 3. Generate video using avatar's default voice
+  // 3. Generate video
   const videoId = await generateVideo({
-    video_inputs: [{
-      character: {
-        type: "avatar",
-        avatar_id: avatar.id, // from details response
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: script,
-        voice_id: avatar.default_voice_id, // pre-matched default voice
-        speed: 1.0,
-      },
-      background: {
-        type: "color",
-        value: "#1a1a2e",
-      },
-    }],
-    dimension: { width, height },
+    type: "avatar",
+    avatar_id: avatarId,
+    script: script,
+    voice_id: avatar.default_voice_id,
+    resolution: resolution,
+    aspect_ratio: aspectRatio,
+    background: {
+      type: "color",
+      value: "#1a1a2e",
+    },
   });
 
   console.log(`Video ID: ${videoId}`);
 
-  // 3. Wait for completion (20 minute timeout - generation can take 15+ min)
-  console.log("Waiting for video generation (typically 5-15 minutes, can be longer)...");
-  const result = await waitForVideo(
-    videoId,
-    process.env.HEYGEN_API_KEY!,
-    (status, elapsed) => {
-      console.log(`  [${Math.round(elapsed / 1000)}s] ${status}`);
-    },
-    1200000 // 20 minute timeout for safety
-  );
+  // 4. Wait for completion (20 minute timeout - generation can take 15+ min)
+  console.log("Waiting for video generation (typically 5-15 minutes)...");
+  const maxAttempts = 120; // 120 * 10s = 20 minutes
+  const pollInterval = 10000;
 
-  return {
-    videoId,
-    videoUrl: result.video_url!,
-    duration: result.duration!,
-    avatarId: avatar.id,
-    voiceId: avatar.default_voice_id,
-    avatarName: avatar.name,
-  };
+  for (let i = 0; i < maxAttempts; i++) {
+    const response = await fetch(
+      `https://api.heygen.com/v3/videos/${videoId}`,
+      { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
+    );
+
+    const json = await response.json();
+
+    if (!response.ok) {
+      const err = json as VideoErrorResponse;
+      throw new Error(`${err.error.code}: ${err.error.message}`);
+    }
+
+    const { data } = json;
+
+    console.log(`  [${Math.round((i * pollInterval) / 1000)}s] ${data.status}`);
+
+    if (data.status === "completed") {
+      return {
+        videoId,
+        videoUrl: data.video_url,
+        duration: data.duration,
+        avatarId: avatarId!,
+        voiceId: avatar.default_voice_id,
+        avatarName: avatar.name,
+      };
+    } else if (data.status === "failed") {
+      throw new Error(data.failure_message || "Video generation failed");
+    }
+
+    await new Promise((r) => setTimeout(r, pollInterval));
+  }
+
+  throw new Error("Video generation timed out after 20 minutes");
 }
 
 // Usage - let it pick an avatar automatically
@@ -591,180 +1286,130 @@ const result = await generateAvatarVideo(
 );
 console.log(`Video ready: ${result.videoUrl}`);
 
-// Or specify a known avatar_id
+// Or specify a known avatar look ID
 const result2 = await generateAvatarVideo(
   "Hello! Welcome to our product demonstration.",
-  { avatarId: "josh_lite3_20230714" }
+  { avatarId: "josh_lite3_20230714", aspectRatio: "9:16" }
 );
 ```
 
-## Transparent Background Videos (WebM)
+### Python
 
-Use WebM **only when you need transparency** - i.e., when the avatar should be overlaid on other video content and you need to see through to what's behind.
+```python
+def generate_avatar_video(
+    script: str,
+    avatar_id: str | None = None,
+    resolution: str = "1080p",
+    aspect_ratio: str = "16:9",
+) -> dict:
+    headers = {"X-Api-Key": os.environ["HEYGEN_API_KEY"]}
 
-**Don't need WebM for:**
-- Avatar with motion graphics/text overlaid ON TOP of avatar
-- Picture-in-picture with solid background
-- Standard presenter videos
+    # 1. List avatar looks if no specific one provided
+    if not avatar_id:
+        print("Listing available avatar looks...")
+        list_resp = requests.get(
+            "https://api.heygen.com/v3/avatars/looks",
+            headers=headers,
+        )
+        list_data = list_resp.json()
+        if not list_resp.ok:
+            err = list_data["error"]
+            raise Exception(f"{err['code']}: {err['message']}")
 
-**Do need WebM for:**
-- Avatar overlaid on screen recording
-- Avatar floating over video background
-- True alpha-channel compositing
+        if not list_data.get("data"):
+            raise Exception("No avatar looks available")
+        avatar_id = list_data["data"][0]["id"]
 
-### WebM Request Fields
+    # 2. Get avatar look details
+    print(f"Getting details for avatar look: {avatar_id}")
+    details_resp = requests.get(
+        f"https://api.heygen.com/v3/avatars/looks/{avatar_id}",
+        headers=headers,
+    )
+    details_data = details_resp.json()
+    if not details_resp.ok:
+        err = details_data["error"]
+        raise Exception(f"{err['code']}: {err['message']}")
 
-**Note:** The WebM endpoint (`/v1/video.webm`) uses a different structure than `/v2/video/generate`.
+    avatar = details_data["data"]
 
-| Field | Type | Req | Description |
-|-------|------|:---:|-------------|
-| `avatar_pose_id` | string | ✓ | Avatar pose ID (from avatar details) |
-| `avatar_style` | string | ✓ | `"normal"` or `"closeUp"` only (no circle) |
-| `input_text` | string | ✓* | Script text (*required if not using input_audio) |
-| `voice_id` | string | ✓* | Voice ID (*required with input_text) |
-| `input_audio` | string | ✓* | Audio URL (*required if not using input_text) |
-| `dimension` | object | | `{width, height}` (default: 1280x720) |
+    if not avatar.get("default_voice_id"):
+        raise Exception(f"Avatar {avatar['name']} has no default voice")
 
-**Either** (`input_text` + `voice_id`) **OR** `input_audio` must be provided, but not both.
+    voice_id = avatar["default_voice_id"]
+    print(f"Using avatar: {avatar['name']} with default voice: {voice_id}")
 
-### curl
+    # 3. Generate video
+    video_id = generate_video({
+        "type": "avatar",
+        "avatar_id": avatar_id,
+        "script": script,
+        "voice_id": voice_id,
+        "resolution": resolution,
+        "aspect_ratio": aspect_ratio,
+        "background": {
+            "type": "color",
+            "value": "#1a1a2e",
+        },
+    })
 
-```bash
-curl -X POST "https://api.heygen.com/v1/video.webm" \
-  -H "X-Api-Key: $HEYGEN_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "avatar_pose_id": "josh_lite3_20230714",
-    "avatar_style": "normal",
-    "input_text": "Hello! This video has a transparent background.",
-    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
-    "dimension": {
-      "width": 1920,
-      "height": 1080
-    }
-  }'
+    print(f"Video ID: {video_id}")
+
+    # 4. Wait for completion (20 minute timeout)
+    print("Waiting for video generation (typically 5-15 minutes)...")
+    max_attempts = 120
+    poll_interval = 10
+
+    for i in range(max_attempts):
+        resp = requests.get(
+            f"https://api.heygen.com/v3/videos/{video_id}",
+            headers=headers,
+        )
+        data = resp.json()
+        if not resp.ok:
+            err = data["error"]
+            raise Exception(f"{err['code']}: {err['message']}")
+
+        status = data["data"]["status"]
+        print(f"  [{i * poll_interval}s] {status}")
+
+        if status == "completed":
+            return {
+                "video_id": video_id,
+                "video_url": data["data"]["video_url"],
+                "duration": data["data"]["duration"],
+                "avatar_id": avatar_id,
+                "voice_id": voice_id,
+                "avatar_name": avatar["name"],
+            }
+        elif status == "failed":
+            raise Exception(
+                data["data"].get("failure_message", "Video generation failed")
+            )
+
+        time.sleep(poll_interval)
+
+    raise Exception("Video generation timed out after 20 minutes")
+
+
+# Usage
+result = generate_avatar_video("Hello! Welcome to our product demonstration.")
+print(f"Video ready: {result['video_url']}")
 ```
 
-### TypeScript
+## Multi-Scene Note
 
-```typescript
-interface WebMVideoRequest {
-  avatar_pose_id: string;                      // Required
-  avatar_style: "normal" | "closeUp";          // Required (no circle support)
-  input_text?: string;                         // Required if not using input_audio
-  voice_id?: string;                           // Required with input_text
-  input_audio?: string;                        // Required if not using input_text
-  dimension?: { width: number; height: number };
-}
-
-async function generateTransparentVideo(
-  script: string,
-  avatarPoseId: string,
-  voiceId: string
-): Promise<string> {
-  const response = await fetch("https://api.heygen.com/v1/video.webm", {
-    method: "POST",
-    headers: {
-      "X-Api-Key": process.env.HEYGEN_API_KEY!,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      avatar_pose_id: avatarPoseId,            // Required
-      avatar_style: "normal",                  // Required: "normal" or "closeUp"
-      input_text: script,                      // Required (with voice_id)
-      voice_id: voiceId,                       // Required (with input_text)
-      dimension: { width: 1920, height: 1080 },
-    }),
-  });
-
-  const { data } = await response.json();
-  return data.video_id;
-}
-```
-
-### When to Use WebM vs MP4
-
-| Scenario | Format | Why |
-|----------|--------|-----|
-| Avatar with overlays on top | **MP4** | Overlays go on top, don't need transparency |
-| Standard presenter | **MP4** | Simpler, more compatible |
-| Loom-style (avatar over screen recording) | **WebM** + `normal`/`closeUp` | Need transparency, crop to circle in post |
-| Avatar floating over video content | **WebM** | Need to see content behind avatar |
-
-**Note:** WebM only supports `normal` and `closeUp` styles. Circle style is not supported for WebM - apply circular masking in your video editor/Remotion instead.
-
-### WebM Example: Loom-Style (Avatar Over Screen Recording)
-
-Generate with `normal` or `closeUp` style (circle not supported for WebM):
-
-```typescript
-// Generate avatar with transparent background
-const videoId = await fetch("https://api.heygen.com/v1/video.webm", {
-  method: "POST",
-  headers: { "X-Api-Key": apiKey, "Content-Type": "application/json" },
-  body: JSON.stringify({
-    avatar_pose_id: avatarPoseId,              // Required
-    avatar_style: "closeUp",                   // Required: "normal" or "closeUp" only
-    input_text: script,                        // Required (with voice_id)
-    voice_id: voiceId,                         // Required (with input_text)
-    dimension: { width: 1920, height: 1080 },
-  }),
-}).then(r => r.json()).then(d => d.data.video_id);
-```
-
-Apply circular masking in Remotion:
-
-```tsx
-import { Video, AbsoluteFill } from "remotion";
-
-export const LoomStyleVideo: React.FC<{
-  screenRecordingUrl: string;
-  avatarWebmUrl: string;
-}> = ({ screenRecordingUrl, avatarWebmUrl }) => {
-  return (
-    <AbsoluteFill>
-      {/* Screen recording as base layer */}
-      <Video src={screenRecordingUrl} style={{ width: "100%", height: "100%" }} />
-
-      {/* Avatar with circular mask applied in CSS */}
-      <Video
-        src={avatarWebmUrl}
-        style={{
-          position: "absolute",
-          bottom: 20,
-          left: 20,
-          width: 150,
-          height: 150,
-          borderRadius: "50%", // Circular mask
-          overflow: "hidden",
-          objectFit: "cover",
-        }}
-      />
-    </AbsoluteFill>
-  );
-};
-```
-
-### Note on Status Polling
-
-WebM videos use the same status endpoint as MP4:
-
-```typescript
-// Same polling as regular videos
-const status = await getVideoStatus(videoId);
-// status.video_url will be a .webm file
-```
+The v3 API creates **one video per request** (single scene). For multi-scene workflows, generate multiple videos and concatenate them in post-production using tools like ffmpeg, Remotion, or a video editor.
 
 ## Best Practices
 
-1. **Preview avatars before generating** - Download `preview_image_url` so user can see what the avatar looks like before committing to a video (see [avatars.md](avatars.md))
-2. **Use avatar's default voice** - Most avatars have a `default_voice_id` that's pre-matched for natural results (see [avatars.md](avatars.md))
-2. **Fallback: match gender manually** - If no default voice, ensure avatar and voice genders match (see [voices.md](voices.md))
-3. **Validate inputs** - Check avatar and voice IDs before generating
-4. **Use test mode** - Test configurations without consuming credits
+1. **Preview avatars before generating** - Download `preview_image_url` so the user can see what the avatar looks like before committing to a video (see [avatars.md](avatars.md))
+2. **Use the avatar's default voice** - Most avatars have a `default_voice_id` that is pre-matched for natural results (see [avatars.md](avatars.md))
+3. **Fallback: match gender manually** - If no default voice, ensure avatar and voice genders match (see [voices.md](voices.md))
+4. **Validate inputs** - Check avatar and voice IDs before generating
 5. **Set generous timeouts** - Use 15-20 minutes; generation often takes 10-15 min, sometimes longer
-6. **Consider async patterns** - For long videos, save video_id and check status later (see [video-status.md](video-status.md))
-7. **Handle errors gracefully** - Implement proper error handling
+6. **Consider async patterns** - For long videos, save `video_id` and check status later (see [video-status.md](video-status.md))
+7. **Handle errors gracefully** - Check `response.ok` and parse the structured `error` object
 8. **Monitor progress** - Implement polling with progress feedback
 9. **Optimize scripts** - Keep scripts concise and natural
-10. **Consider dimensions** - Match dimensions to your use case (see [dimensions.md](dimensions.md))
+10. **Match resolution to use case** - Use `"9:16"` for mobile/social, `"16:9"` for presentations and web

--- a/skills/avatar-video/references/video-status.md
+++ b/skills/avatar-video/references/video-status.md
@@ -9,54 +9,64 @@ After generating a video, you need to poll for status until the video is complet
 
 ## MCP Tool (Preferred)
 
-If the HeyGen MCP server is connected, use `mcp__heygen__get_video` with the `videoId` parameter. It returns status, video_url, thumbnail_url, duration, title, gif_url, captioned_video_url, and other metadata in a single call.
+If the HeyGen MCP server is connected, use `mcp__heygen__get_video` with the `videoId` parameter. It returns status, video_url, thumbnail_url, duration, title, gif_url, captioned_video_url, video_page_url, and other metadata in a single call.
 
 ## Checking Video Status (Direct API)
 
 ### curl
 
 ```bash
-curl -X GET "https://api.heygen.com/v2/videos/YOUR_VIDEO_ID" \
+curl -X GET "https://api.heygen.com/v3/videos/YOUR_VIDEO_ID" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
 ### TypeScript
 
 ```typescript
+interface VideoDetail {
+  id: string;
+  title: string;
+  status: "pending" | "processing" | "completed" | "failed";
+  created_at: number;              // unix timestamp
+  completed_at: number | null;     // unix timestamp
+  video_url: string | null;
+  thumbnail_url: string | null;
+  gif_url: string | null;
+  captioned_video_url: string | null;
+  subtitle_url: string | null;
+  duration: number | null;
+  folder_id: string | null;
+  output_language: string | null;
+  failure_code: string | null;
+  failure_message: string | null;
+  video_page_url: string | null;   // link to video in HeyGen app
+}
+
 interface VideoStatusResponse {
-  error: null | string;
-  data: {
-    id: string;
-    status: "pending" | "processing" | "completed" | "failed";
-    video_url?: string;
-    thumbnail_url?: string;
-    duration?: number;
-    title?: string;
-    created_at?: string;
-    completed_at?: string;
-    gif_url?: string;
-    captioned_video_url?: string;
-    subtitle_url?: string;
-    folder_id?: string;
-    output_language?: string;
-    failure_code?: string;
-    failure_message?: string;
+  data: VideoDetail;
+}
+
+interface VideoErrorResponse {
+  error: {
+    code: string;
+    message: string;
   };
 }
 
-async function getVideoStatus(videoId: string): Promise<VideoStatusResponse["data"]> {
+async function getVideoStatus(videoId: string): Promise<VideoDetail> {
   const response = await fetch(
-    `https://api.heygen.com/v2/videos/${videoId}`,
+    `https://api.heygen.com/v3/videos/${videoId}`,
     { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
   );
 
-  const json: VideoStatusResponse = await response.json();
+  const json = await response.json();
 
-  if (json.error) {
-    throw new Error(json.error);
+  if (!response.ok) {
+    const err = json as VideoErrorResponse;
+    throw new Error(`${err.error.code}: ${err.error.message}`);
   }
 
-  return json.data;
+  return (json as VideoStatusResponse).data;
 }
 ```
 
@@ -68,13 +78,14 @@ import os
 
 def get_video_status(video_id: str) -> dict:
     response = requests.get(
-        f"https://api.heygen.com/v2/videos/{video_id}",
+        f"https://api.heygen.com/v3/videos/{video_id}",
         headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]}
     )
 
     data = response.json()
-    if data.get("error"):
-        raise Exception(data["error"])
+    if not response.ok:
+        err = data["error"]
+        raise Exception(f"{err['code']}: {err['message']}")
 
     return data["data"]
 ```
@@ -111,21 +122,23 @@ Video generation typically takes **5-15 minutes**, but can exceed 20 minutes dur
 
 ```json
 {
-  "error": null,
   "data": {
-    "id": "abc123",
+    "id": "v_abc123def456",
+    "title": "My Video",
     "status": "completed",
+    "created_at": 1705312200,
+    "completed_at": 1705312680,
     "video_url": "https://files.heygen.ai/video/abc123.mp4",
     "thumbnail_url": "https://files.heygen.ai/thumbnail/abc123.jpg",
-    "duration": 45.2,
-    "title": "My Video",
-    "created_at": "2024-01-15T10:30:00Z",
-    "completed_at": "2024-01-15T10:38:00Z",
     "gif_url": "https://files.heygen.ai/gif/abc123.gif",
     "captioned_video_url": null,
     "subtitle_url": null,
+    "duration": 45.2,
     "folder_id": null,
-    "output_language": "en"
+    "output_language": null,
+    "failure_code": null,
+    "failure_message": null,
+    "video_page_url": "https://app.heygen.com/video/abc123def456"
   }
 }
 ```
@@ -134,12 +147,34 @@ Video generation typically takes **5-15 minutes**, but can exceed 20 minutes dur
 
 ```json
 {
-  "error": null,
   "data": {
-    "id": "abc123",
+    "id": "v_abc123def456",
+    "title": "My Video",
     "status": "failed",
+    "created_at": 1705312200,
+    "completed_at": null,
+    "video_url": null,
+    "thumbnail_url": null,
+    "gif_url": null,
+    "captioned_video_url": null,
+    "subtitle_url": null,
+    "duration": null,
+    "folder_id": null,
+    "output_language": null,
     "failure_code": "script_too_long",
-    "failure_message": "Script too long for selected avatar"
+    "failure_message": "Script too long for selected avatar",
+    "video_page_url": null
+  }
+}
+```
+
+### Error Response
+
+```json
+{
+  "error": {
+    "code": "video_not_found",
+    "message": "Video with the given ID was not found"
   }
 }
 ```
@@ -352,7 +387,7 @@ async function downloadVideo(videoUrl: string, outputPath = "./output/video.mp4"
 async function generateAndDownloadVideo(config: VideoConfig): Promise<string> {
   // 1. Generate video
   const generateResponse = await fetch(
-    "https://api.heygen.com/v2/video/generate",
+    "https://api.heygen.com/v3/videos",
     {
       method: "POST",
       headers: {
@@ -367,7 +402,7 @@ async function generateAndDownloadVideo(config: VideoConfig): Promise<string> {
   const videoId = generateData.video_id;
   console.log(`Video ID: ${videoId}`);
 
-  // 2. Poll for completion
+  // 2. Poll for completion (uses v3 status endpoint)
   const videoUrl = await waitForVideoWithProgress(
     videoId,
     (status, elapsed) => {
@@ -392,7 +427,7 @@ For long-running generations, save the video_id and check status later rather th
 ```typescript
 interface PendingVideo {
   videoId: string;
-  createdAt: string;
+  createdAt: number;  // unix timestamp
   script: string;
   avatarId: string;
   voiceId: string;
@@ -403,7 +438,7 @@ async function startVideoGeneration(config: VideoGenerateRequest): Promise<Pendi
 
   const pending: PendingVideo = {
     videoId,
-    createdAt: new Date().toISOString(),
+    createdAt: Math.floor(Date.now() / 1000),
     script: config.video_inputs[0].voice.input_text!,
     avatarId: config.video_inputs[0].character.avatar_id!,
     voiceId: config.video_inputs[0].voice.voice_id!,
@@ -431,8 +466,8 @@ async function checkVideoStatus(): Promise<void> {
     fs.readFileSync("pending-video.json", "utf-8")
   );
 
-  const elapsed = Date.now() - new Date(pending.createdAt).getTime();
-  console.log(`Checking video ${pending.videoId} (started ${Math.round(elapsed / 60000)} min ago)...`);
+  const elapsedSeconds = Math.floor(Date.now() / 1000) - pending.createdAt;
+  console.log(`Checking video ${pending.videoId} (started ${Math.round(elapsedSeconds / 60)} min ago)...`);
 
   const status = await getVideoStatus(pending.videoId);
 
@@ -440,6 +475,9 @@ async function checkVideoStatus(): Promise<void> {
     case "completed":
       console.log(`Video ready: ${status.video_url}`);
       console.log(`Duration: ${status.duration}s`);
+      if (status.video_page_url) {
+        console.log(`View in app: ${status.video_page_url}`);
+      }
       // Clean up pending file
       fs.unlinkSync("pending-video.json");
       // Save result
@@ -451,6 +489,7 @@ async function checkVideoStatus(): Promise<void> {
         title: status.title,
         createdAt: status.created_at,
         completedAt: status.completed_at,
+        videoPageUrl: status.video_page_url,
       }, null, 2));
       break;
     case "failed":
@@ -480,8 +519,8 @@ async function main() {
 
   if (shouldWait) {
     // Poll until complete (with 20 min timeout)
-    const result = await waitForVideo(pending.videoId, apiKey, onProgress, 1200000);
-    console.log(`Done: ${result.video_url}`);
+    const result = await waitForVideo(pending.videoId, 1200000);
+    console.log(`Done: ${result}`);
   } else {
     // Just check once and report
     await checkVideoStatus();
@@ -497,6 +536,7 @@ Instead of polling, you can use webhooks to receive notifications when videos co
 
 1. **Use exponential backoff** - Increase poll intervals for long-running jobs
 2. **Set reasonable timeouts** - Most videos complete within 10 minutes
-3. **Handle failures gracefully** - Check error messages for actionable feedback
+3. **Handle failures gracefully** - Check `failure_code` and `failure_message` for actionable feedback
 4. **Consider webhooks** - For production systems, webhooks are more efficient than polling
 5. **Cache video URLs** - Downloaded video URLs are valid for a limited time
+6. **Use `video_page_url`** - Link users directly to the video in the HeyGen app when available

--- a/skills/avatar-video/references/voices.md
+++ b/skills/avatar-video/references/voices.md
@@ -1,53 +1,51 @@
 ---
 name: voices
-description: Listing voices, locales, speed/pitch configuration for HeyGen
+description: Listing voices via v3 API, locales, speed/pitch configuration, server-side filtering for HeyGen
 ---
 
 # HeyGen Voices
 
-HeyGen provides a wide variety of AI voices for different languages, accents, and styles. Voices convert your text script into natural-sounding speech.
+HeyGen provides a wide variety of AI voices for different languages, accents, and styles. The v3 voices endpoint (`GET /v3/voices`) is a unified API that replaces both the v2 video voices and v1 TTS audio voices endpoints, with built-in server-side filtering and cursor-based pagination.
 
 ## Listing Available Voices
 
 ### curl
 
 ```bash
-curl -X GET "https://api.heygen.com/v2/voices" \
+curl -X GET "https://api.heygen.com/v3/voices?limit=20" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
 ### TypeScript
 
 ```typescript
-interface Voice {
+interface AudioVoiceItem {
   voice_id: string;
   name: string;
   language: string;
-  gender: "male" | "female";
-  preview_audio: string;
+  gender: string;
+  preview_audio_url: string | null;
   support_pause: boolean;
-  emotion_support: boolean;
+  support_locale: boolean;
+  type: "public" | "private";
 }
 
 interface VoicesResponse {
-  error: null | string;
-  data: {
-    voices: Voice[];
-  };
+  data: AudioVoiceItem[];
+  has_more: boolean;
+  next_token: string | null;
 }
 
-async function listVoices(): Promise<Voice[]> {
-  const response = await fetch("https://api.heygen.com/v2/voices", {
-    headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
-  });
+async function listVoices(limit = 20): Promise<AudioVoiceItem[]> {
+  const response = await fetch(
+    `https://api.heygen.com/v3/voices?limit=${limit}`,
+    {
+      headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
+    }
+  );
 
   const json: VoicesResponse = await response.json();
-
-  if (json.error) {
-    throw new Error(json.error);
-  }
-
-  return json.data.voices;
+  return json.data;
 }
 ```
 
@@ -57,46 +55,45 @@ async function listVoices(): Promise<Voice[]> {
 import requests
 import os
 
-def list_voices() -> list:
+def list_voices(limit: int = 20) -> list:
     response = requests.get(
-        "https://api.heygen.com/v2/voices",
-        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]}
+        "https://api.heygen.com/v3/voices",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        params={"limit": limit},
     )
 
     data = response.json()
-    if data.get("error"):
-        raise Exception(data["error"])
-
-    return data["data"]["voices"]
+    return data["data"]
 ```
 
 ## Response Format
 
 ```json
 {
-  "error": null,
-  "data": {
-    "voices": [
-      {
-        "voice_id": "1bd001e7e50f421d891986aad5158bc8",
-        "name": "Sara",
-        "language": "English",
-        "gender": "female",
-        "preview_audio": "https://files.heygen.ai/...",
-        "support_pause": true,
-        "emotion_support": true
-      },
-      {
-        "voice_id": "de8b5d78f2e0485f88d1e9f5c8e7f9a6",
-        "name": "Paul",
-        "language": "English",
-        "gender": "male",
-        "preview_audio": "https://files.heygen.ai/...",
-        "support_pause": true,
-        "emotion_support": false
-      }
-    ]
-  }
+  "data": [
+    {
+      "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+      "name": "Sara",
+      "language": "English",
+      "gender": "female",
+      "preview_audio_url": "https://files.heygen.ai/...",
+      "support_pause": true,
+      "support_locale": true,
+      "type": "public"
+    },
+    {
+      "voice_id": "de8b5d78f2e0485f88d1e9f5c8e7f9a6",
+      "name": "Paul",
+      "language": "English",
+      "gender": "male",
+      "preview_audio_url": "https://files.heygen.ai/...",
+      "support_pause": true,
+      "support_locale": false,
+      "type": "public"
+    }
+  ],
+  "has_more": true,
+  "next_token": "eyJsYXN0X2lkIjoiZGU4YjVkNzhmMmUwNDg1Zjg4ZDFlOWY1YzhlN2Y5YTYifQ=="
 }
 ```
 
@@ -125,67 +122,133 @@ HeyGen supports many languages including:
 
 ### Basic Voice Usage
 
+In the v3 API, video generation uses a flat structure with `script` and `voice_id` fields inside each scene's `audio` object.
+
+#### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scenes": [
+      {
+        "avatar": {
+          "avatar_id": "josh_lite3_20230714",
+          "type": "avatar"
+        },
+        "audio": {
+          "script": "Hello! Welcome to our presentation.",
+          "voice_id": "1bd001e7e50f421d891986aad5158bc8"
+        }
+      }
+    ]
+  }'
+```
+
+#### TypeScript
+
 ```typescript
-const videoConfig = {
-  video_inputs: [
+const videoPayload = {
+  scenes: [
     {
-      character: {
-        type: "avatar",
+      avatar: {
         avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
+        type: "avatar",
       },
-      voice: {
-        type: "text",
-        input_text: "Hello! Welcome to our presentation.",
+      audio: {
+        script: "Hello! Welcome to our presentation.",
         voice_id: "1bd001e7e50f421d891986aad5158bc8",
+      },
+    },
+  ],
+};
+
+const response = await fetch("https://api.heygen.com/v3/videos", {
+  method: "POST",
+  headers: {
+    "X-Api-Key": process.env.HEYGEN_API_KEY!,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify(videoPayload),
+});
+```
+
+#### Python
+
+```python
+import requests
+import os
+
+payload = {
+    "scenes": [
+        {
+            "avatar": {
+                "avatar_id": "josh_lite3_20230714",
+                "type": "avatar",
+            },
+            "audio": {
+                "script": "Hello! Welcome to our presentation.",
+                "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+            },
+        }
+    ]
+}
+
+response = requests.post(
+    "https://api.heygen.com/v3/videos",
+    headers={
+        "X-Api-Key": os.environ["HEYGEN_API_KEY"],
+        "Content-Type": "application/json",
+    },
+    json=payload,
+)
+```
+
+### Voice with Speed and Pitch Adjustment
+
+Speed and pitch settings are specified in a `voice_settings` object within the `audio` block.
+
+```typescript
+const videoPayload = {
+  scenes: [
+    {
+      avatar: {
+        avatar_id: "josh_lite3_20230714",
+        type: "avatar",
+      },
+      audio: {
+        script: "This is spoken at a faster pace with higher pitch.",
+        voice_id: "1bd001e7e50f421d891986aad5158bc8",
+        voice_settings: {
+          speed: 1.2, // 1.0 is normal, range: 0.5 - 2.0
+          pitch: 10,  // Range: -20 to 20
+        },
       },
     },
   ],
 };
 ```
 
-### Voice with Speed Adjustment
-
-```typescript
-const videoConfig = {
-  video_inputs: [
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: "This is spoken at a faster pace.",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-        speed: 1.2, // 1.0 is normal, range: 0.5 - 2.0
-      },
-    },
-  ],
-};
-```
-
-### Voice with Pitch Adjustment
-
-```typescript
-const videoConfig = {
-  video_inputs: [
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: "This has a higher pitch.",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-        pitch: 10, // Range: -20 to 20
-      },
-    },
-  ],
-};
+```python
+payload = {
+    "scenes": [
+        {
+            "avatar": {
+                "avatar_id": "josh_lite3_20230714",
+                "type": "avatar",
+            },
+            "audio": {
+                "script": "This is spoken at a faster pace with higher pitch.",
+                "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+                "voice_settings": {
+                    "speed": 1.2,
+                    "pitch": 10,
+                },
+            },
+        }
+    ]
+}
 ```
 
 ## Adding Pauses with Break Tags
@@ -204,10 +267,10 @@ Where `X` is the duration in seconds (e.g., `1s`, `1.5s`, `0.5s`).
 
 | Rule | Example |
 |------|---------|
-| Use seconds with "s" suffix | `<break time="1.5s"/>` ✓ |
-| Must have space before tag | `word <break time="1s"/>` ✓ |
-| Must have space after tag | `<break time="1s"/> word` ✓ |
-| Self-closing tag | `<break time="1s"/>` ✓ |
+| Use seconds with "s" suffix | `<break time="1.5s"/>` |
+| Must have space before tag | `word <break time="1s"/>` |
+| Must have space after tag | `<break time="1s"/> word` |
+| Self-closing tag | `<break time="1s"/>` |
 
 **Incorrect:** `word<break time="1s"/>word` (no spaces)
 **Correct:** `word <break time="1s"/> word`
@@ -238,17 +301,15 @@ First, let's look at the dashboard. <break time="1.5s"/>
 As you can see, it's incredibly intuitive.
 `;
 
-const videoConfig = {
-  video_inputs: [
+const videoPayload = {
+  scenes: [
     {
-      character: {
-        type: "avatar",
+      avatar: {
         avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
+        type: "avatar",
       },
-      voice: {
-        type: "text",
-        input_text: scriptWithPauses,
+      audio: {
+        script: scriptWithPauses,
         voice_id: "1bd001e7e50f421d891986aad5158bc8",
       },
     },
@@ -276,19 +337,40 @@ Multiple consecutive break tags are automatically combined:
 
 ## Using Custom Audio Instead of TTS
 
-Instead of text-to-speech, you can provide your own audio:
+Instead of text-to-speech, you can provide your own audio via the `audio_url` field:
+
+### curl
+
+```bash
+curl -X POST "https://api.heygen.com/v3/videos" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scenes": [
+      {
+        "avatar": {
+          "avatar_id": "josh_lite3_20230714",
+          "type": "avatar"
+        },
+        "audio": {
+          "audio_url": "https://example.com/my-audio.mp3"
+        }
+      }
+    ]
+  }'
+```
+
+### TypeScript
 
 ```typescript
-const videoConfig = {
-  video_inputs: [
+const videoPayload = {
+  scenes: [
     {
-      character: {
-        type: "avatar",
+      avatar: {
         avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
+        type: "avatar",
       },
-      voice: {
-        type: "audio",
+      audio: {
         audio_url: "https://example.com/my-audio.mp3",
       },
     },
@@ -296,90 +378,274 @@ const videoConfig = {
 };
 ```
 
+### Python
+
+```python
+payload = {
+    "scenes": [
+        {
+            "avatar": {
+                "avatar_id": "josh_lite3_20230714",
+                "type": "avatar",
+            },
+            "audio": {
+                "audio_url": "https://example.com/my-audio.mp3",
+            },
+        }
+    ]
+}
+```
+
 ## Filtering Voices
+
+The v3 API supports server-side filtering via query parameters, eliminating the need for client-side filtering.
+
+### Available Filter Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | `"public"` \| `"private"` | Filter by voice type |
+| `engine` | string | Filter by voice engine (e.g., `"starfish"`) |
+| `language` | string | Filter by language (e.g., `"English"`) |
+| `gender` | `"male"` \| `"female"` | Filter by gender |
+| `limit` | 1-100 | Results per page |
+| `token` | string | Cursor for next page |
 
 ### By Language
 
+#### curl
+
+```bash
+curl -X GET "https://api.heygen.com/v3/voices?language=English&limit=20" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+#### TypeScript
+
 ```typescript
-function filterByLanguage(voices: Voice[], language: string): Voice[] {
-  return voices.filter((v) =>
-    v.language.toLowerCase().includes(language.toLowerCase())
+async function getVoicesByLanguage(language: string): Promise<AudioVoiceItem[]> {
+  const params = new URLSearchParams({ language, limit: "20" });
+  const response = await fetch(
+    `https://api.heygen.com/v3/voices?${params}`,
+    {
+      headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
+    }
   );
+
+  const json: VoicesResponse = await response.json();
+  return json.data;
 }
 
-const englishVoices = filterByLanguage(voices, "english");
-const spanishVoices = filterByLanguage(voices, "spanish");
+const englishVoices = await getVoicesByLanguage("English");
+const spanishVoices = await getVoicesByLanguage("Spanish");
+```
+
+#### Python
+
+```python
+def get_voices_by_language(language: str) -> list:
+    response = requests.get(
+        "https://api.heygen.com/v3/voices",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        params={"language": language, "limit": 20},
+    )
+    return response.json()["data"]
+
+english_voices = get_voices_by_language("English")
+spanish_voices = get_voices_by_language("Spanish")
 ```
 
 ### By Gender
 
-```typescript
-function filterByGender(voices: Voice[], gender: "male" | "female"): Voice[] {
-  return voices.filter((v) => v.gender === gender);
-}
+#### curl
 
-const femaleVoices = filterByGender(voices, "female");
+```bash
+curl -X GET "https://api.heygen.com/v3/voices?gender=female&limit=20" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
-### By Features
+#### TypeScript
 
 ```typescript
-function filterByFeatures(
-  voices: Voice[],
-  options: { supportPause?: boolean; emotionSupport?: boolean }
-): Voice[] {
-  return voices.filter((v) => {
-    if (options.supportPause !== undefined && v.support_pause !== options.supportPause) {
-      return false;
+async function getVoicesByGender(
+  gender: "male" | "female"
+): Promise<AudioVoiceItem[]> {
+  const params = new URLSearchParams({ gender, limit: "20" });
+  const response = await fetch(
+    `https://api.heygen.com/v3/voices?${params}`,
+    {
+      headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
     }
-    if (options.emotionSupport !== undefined && v.emotion_support !== options.emotionSupport) {
-      return false;
-    }
-    return true;
-  });
+  );
+
+  const json: VoicesResponse = await response.json();
+  return json.data;
 }
 
-const expressiveVoices = filterByFeatures(voices, { emotionSupport: true });
+const femaleVoices = await getVoicesByGender("female");
+```
+
+#### Python
+
+```python
+def get_voices_by_gender(gender: str) -> list:
+    response = requests.get(
+        "https://api.heygen.com/v3/voices",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        params={"gender": gender, "limit": 20},
+    )
+    return response.json()["data"]
+
+female_voices = get_voices_by_gender("female")
+```
+
+### By Engine (TTS-Compatible Voices)
+
+To list only TTS-compatible voices, filter by `engine=starfish`:
+
+```bash
+curl -X GET "https://api.heygen.com/v3/voices?engine=starfish&limit=20" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+### Combined Filters
+
+```bash
+curl -X GET "https://api.heygen.com/v3/voices?language=English&gender=female&type=public&limit=50" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
 ## Voice Selection Helper
+
+Uses server-side filtering and cursor-based pagination to find matching voices across all pages.
+
+### TypeScript
 
 ```typescript
 interface VoiceSelectionCriteria {
   language?: string;
   gender?: "male" | "female";
-  supportPause?: boolean;
-  emotionSupport?: boolean;
+  type?: "public" | "private";
+  engine?: string;
 }
 
-async function findVoice(criteria: VoiceSelectionCriteria): Promise<Voice | null> {
-  const voices = await listVoices();
+async function findVoice(
+  criteria: VoiceSelectionCriteria
+): Promise<AudioVoiceItem | null> {
+  const params = new URLSearchParams({ limit: "50" });
+  if (criteria.language) params.set("language", criteria.language);
+  if (criteria.gender) params.set("gender", criteria.gender);
+  if (criteria.type) params.set("type", criteria.type);
+  if (criteria.engine) params.set("engine", criteria.engine);
 
-  const filtered = voices.filter((v) => {
-    if (criteria.language && !v.language.toLowerCase().includes(criteria.language.toLowerCase())) {
-      return false;
+  const response = await fetch(
+    `https://api.heygen.com/v3/voices?${params}`,
+    {
+      headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
     }
-    if (criteria.gender && v.gender !== criteria.gender) {
-      return false;
-    }
-    if (criteria.supportPause !== undefined && v.support_pause !== criteria.supportPause) {
-      return false;
-    }
-    if (criteria.emotionSupport !== undefined && v.emotion_support !== criteria.emotionSupport) {
-      return false;
-    }
-    return true;
-  });
+  );
 
-  return filtered[0] || null;
+  const json: VoicesResponse = await response.json();
+  return json.data[0] || null;
 }
 
 // Usage
 const voice = await findVoice({
-  language: "english",
+  language: "English",
   gender: "female",
-  emotionSupport: true,
+  type: "public",
 });
+```
+
+### Python
+
+```python
+def find_voice(
+    language: str | None = None,
+    gender: str | None = None,
+    voice_type: str | None = None,
+    engine: str | None = None,
+) -> dict | None:
+    params: dict = {"limit": 50}
+    if language:
+        params["language"] = language
+    if gender:
+        params["gender"] = gender
+    if voice_type:
+        params["type"] = voice_type
+    if engine:
+        params["engine"] = engine
+
+    response = requests.get(
+        "https://api.heygen.com/v3/voices",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        params=params,
+    )
+
+    data = response.json()["data"]
+    return data[0] if data else None
+
+# Usage
+voice = find_voice(language="English", gender="female", voice_type="public")
+```
+
+### Paginating Through All Results
+
+```typescript
+async function listAllVoices(
+  criteria: VoiceSelectionCriteria = {}
+): Promise<AudioVoiceItem[]> {
+  const allVoices: AudioVoiceItem[] = [];
+  let token: string | null = null;
+
+  do {
+    const params = new URLSearchParams({ limit: "100" });
+    if (criteria.language) params.set("language", criteria.language);
+    if (criteria.gender) params.set("gender", criteria.gender);
+    if (criteria.type) params.set("type", criteria.type);
+    if (criteria.engine) params.set("engine", criteria.engine);
+    if (token) params.set("token", token);
+
+    const response = await fetch(
+      `https://api.heygen.com/v3/voices?${params}`,
+      {
+        headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
+      }
+    );
+
+    const json: VoicesResponse = await response.json();
+    allVoices.push(...json.data);
+    token = json.has_more ? json.next_token : null;
+  } while (token);
+
+  return allVoices;
+}
+```
+
+```python
+def list_all_voices(**filters) -> list:
+    all_voices = []
+    token = None
+
+    while True:
+        params: dict = {"limit": 100, **filters}
+        if token:
+            params["token"] = token
+
+        response = requests.get(
+            "https://api.heygen.com/v3/voices",
+            headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+            params=params,
+        )
+
+        result = response.json()
+        all_voices.extend(result["data"])
+
+        if not result.get("has_more"):
+            break
+        token = result.get("next_token")
+
+    return all_voices
 ```
 
 ## Multi-Language Videos
@@ -387,29 +653,25 @@ const voice = await findVoice({
 Create videos with different languages per scene:
 
 ```typescript
-const multiLanguageConfig = {
-  video_inputs: [
+const multiLanguagePayload = {
+  scenes: [
     {
-      character: {
-        type: "avatar",
+      avatar: {
         avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
+        type: "avatar",
       },
-      voice: {
-        type: "text",
-        input_text: "Hello! Welcome to our global product launch.",
+      audio: {
+        script: "Hello! Welcome to our global product launch.",
         voice_id: "english_voice_id",
       },
     },
     {
-      character: {
-        type: "avatar",
+      avatar: {
         avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
+        type: "avatar",
       },
-      voice: {
-        type: "text",
-        input_text: "Hola! Bienvenidos al lanzamiento global de nuestro producto.",
+      audio: {
+        script: "Hola! Bienvenidos al lanzamiento global de nuestro producto.",
         voice_id: "spanish_voice_id",
       },
     },
@@ -421,85 +683,132 @@ const multiLanguageConfig = {
 
 ### Recommended: Use Avatar's Default Voice
 
-Many avatars have a `default_voice_id` that's pre-matched. **This is the best approach.**
+Many avatars have a `default_voice_id` that is pre-matched. Use `GET /v3/avatars/looks` to find it.
+
+#### curl
+
+```bash
+curl -X GET "https://api.heygen.com/v3/avatars/looks?limit=20" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+#### TypeScript
 
 ```typescript
-// Using v2 API to get avatar with default voice
 const response = await fetch(
-  "https://api.heygen.com/v2/avatar_group.list?include_public=true",
+  "https://api.heygen.com/v3/avatars/looks?limit=20",
   { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
 );
 const { data } = await response.json();
 
-// Find avatar with a default voice
-const avatar = data.avatar_group_list.find((a: any) => a.default_voice_id);
+// Find an avatar look with a default voice
+const look = data.find((l: any) => l.default_voice_id);
 
-if (avatar) {
-  const videoConfig = {
-    video_inputs: [{
-      character: { type: "avatar", avatar_id: avatar.id },
-      voice: {
-        type: "text",
-        input_text: script,
-        voice_id: avatar.default_voice_id, // Pre-matched voice
+if (look) {
+  const videoPayload = {
+    scenes: [
+      {
+        avatar: {
+          avatar_id: look.avatar_id,
+          type: "avatar",
+        },
+        audio: {
+          script: "Hello! This voice was pre-matched to this avatar.",
+          voice_id: look.default_voice_id,
+        },
       },
-    }],
+    ],
   };
 }
+```
+
+#### Python
+
+```python
+response = requests.get(
+    "https://api.heygen.com/v3/avatars/looks",
+    headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+    params={"limit": 20},
+)
+looks = response.json()["data"]
+
+# Find a look with a default voice
+look = next((l for l in looks if l.get("default_voice_id")), None)
+
+if look:
+    payload = {
+        "scenes": [
+            {
+                "avatar": {
+                    "avatar_id": look["avatar_id"],
+                    "type": "avatar",
+                },
+                "audio": {
+                    "script": "Hello! This voice was pre-matched to this avatar.",
+                    "voice_id": look["default_voice_id"],
+                },
+            }
+        ]
+    }
 ```
 
 See [avatars.md](avatars.md) for complete examples.
 
 ### Fallback: Match Gender Manually
 
-If avatar has no default voice, match genders manually:
+If the avatar has no default voice, use server-side gender filtering to find a match:
 
 ```typescript
-interface AvatarVoicePair {
-  avatarId: string;
-  voiceId: string;
-  gender: "male" | "female";
-}
+async function findMatchingVoiceForAvatar(
+  avatarGender: "male" | "female",
+  language = "English"
+): Promise<AudioVoiceItem | null> {
+  const params = new URLSearchParams({
+    gender: avatarGender,
+    language,
+    type: "public",
+    limit: "1",
+  });
 
-async function findMatchingAvatarAndVoice(
-  preferredGender?: "male" | "female"
-): Promise<AvatarVoicePair> {
-  const [avatars, voices] = await Promise.all([
-    listAvatars(),
-    listVoices(),
-  ]);
-
-  // Default to male if no preference
-  const gender = preferredGender || "male";
-
-  // Find avatar with matching gender
-  const avatar = avatars.find((a) => a.gender === gender);
-  if (!avatar) {
-    throw new Error(`No ${gender} avatar available`);
-  }
-
-  // Find voice with matching gender AND language
-  const voice = voices.find(
-    (v) => v.gender === gender && v.language.toLowerCase().includes("english")
+  const response = await fetch(
+    `https://api.heygen.com/v3/voices?${params}`,
+    {
+      headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
+    }
   );
-  if (!voice) {
-    throw new Error(`No ${gender} English voice available`);
-  }
 
-  return {
-    avatarId: avatar.avatar_id,
-    voiceId: voice.voice_id,
-    gender,
-  };
+  const json: VoicesResponse = await response.json();
+  return json.data[0] || null;
 }
+```
+
+```python
+def find_matching_voice_for_avatar(
+    avatar_gender: str, language: str = "English"
+) -> dict | None:
+    response = requests.get(
+        "https://api.heygen.com/v3/voices",
+        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        params={
+            "gender": avatar_gender,
+            "language": language,
+            "type": "public",
+            "limit": 1,
+        },
+    )
+    data = response.json()["data"]
+    return data[0] if data else None
 ```
 
 ## Best Practices
 
 1. **Match voice gender to avatar** - Always pair male voices with male avatars, female with female
-2. **Match voice to content** - Use professional voices for business content
-3. **Test voice previews** - Listen to preview audio before selecting
-4. **Consider locale** - Match voice accent to target audience
-5. **Use natural pacing** - Adjust speed for clarity, typically 0.9-1.1x
-6. **Add pauses** - Use SSML breaks for more natural speech flow
-7. **Validate availability** - Always verify voice_id exists before using
+2. **Use server-side filters** - Filter by `language`, `gender`, `type`, and `engine` in the query rather than fetching all voices and filtering client-side
+3. **Use avatar default voices** - Prefer the `default_voice_id` from `GET /v3/avatars/looks` for the best avatar-voice pairing
+4. **Test voice previews** - Listen to `preview_audio_url` before selecting a voice
+5. **Consider locale** - Match voice accent to target audience
+6. **Use natural pacing** - Adjust speed via `voice_settings.speed` for clarity, typically 0.9-1.1x
+7. **Add pauses** - Use SSML `<break>` tags for more natural speech flow
+8. **Paginate large results** - Use `token`/`has_more` to iterate through all available voices when needed
+9. **Validate availability** - Always verify `voice_id` exists before using it in video generation
+10. **Use engine filter for TTS** - When you need TTS-compatible voices only, pass `engine=starfish`

--- a/skills/create-video/SKILL.md
+++ b/skills/create-video/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: create-video
 description: |
-  Create videos from a text prompt using HeyGen's Video Agent. Use when: (1) Creating a video from a description or idea, (2) Generating explainer, demo, or marketing videos from a prompt, (3) Making a video without specifying exact avatars, voices, or scenes, (4) Quick video prototyping or drafts, (5) One-shot prompt-to-video generation, (6) User says "make me a video" or "create a video about X".
-homepage: https://docs.heygen.com/reference/generate-video-agent
+  Create videos from a text prompt using HeyGen's Video Agent (POST /v3/video-agents). The default for most video requests — AI handles script, avatar, visuals, voiceover, and captions automatically. Use when: (1) Creating a video from a description or idea, (2) Generating explainer, demo, or marketing videos from a prompt, (3) Making a video without specifying exact avatars, voices, or scenes, (4) Quick video prototyping or drafts, (5) User says "make me a video" or "create a video about X". For precise control over specific avatars, exact scripts, or per-scene configuration, use the avatar-video skill instead.
+homepage: https://docs.heygen.com/reference/create-video-with-video-agent
 allowed-tools: mcp__heygen__*
 metadata:
   openclaw:
@@ -21,7 +21,7 @@ Generate complete videos from a text prompt. Describe what you want and the AI h
 All requests require the `X-Api-Key` header. Set the `HEYGEN_API_KEY` environment variable.
 
 ```bash
-curl -X POST "https://api.heygen.com/v1/video_agent/generate" \
+curl -X POST "https://api.heygen.com/v3/video-agents" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"prompt": "Create a 60-second product demo video."}'
@@ -33,10 +33,10 @@ If HeyGen MCP tools are available (`mcp__heygen__*`), **prefer them** over direc
 
 | Task | MCP Tool | Fallback (Direct API) |
 |------|----------|----------------------|
-| Generate video from prompt | `mcp__heygen__generate_video_agent` | `POST /v1/video_agent/generate` |
-| Check video status / get URL | `mcp__heygen__get_video` | `GET /v2/videos/{video_id}` |
-| List account videos | `mcp__heygen__list_videos` | `GET /v2/videos` |
-| Delete a video | `mcp__heygen__delete_video` | `DELETE /v2/videos/{video_id}` |
+| Generate video from prompt | `mcp__heygen__generate_video_agent` | `POST /v3/video-agents` |
+| Check video status / get URL | `mcp__heygen__get_video` | `GET /v3/videos/{video_id}` |
+| List account videos | `mcp__heygen__list_videos` | `GET /v3/videos` |
+| Delete a video | `mcp__heygen__delete_video` | `DELETE /v3/videos/{video_id}` |
 
 If no HeyGen MCP tools are available, use direct HTTP API calls as documented in the reference files.
 
@@ -51,50 +51,30 @@ Always use [prompt-optimizer.md](references/prompt-optimizer.md) guidelines to s
 
 **Without MCP tools (direct API):**
 1. Write an optimized prompt using [prompt-optimizer.md](references/prompt-optimizer.md) → [visual-styles.md](references/visual-styles.md)
-2. `POST /v1/video_agent/generate` — see [video-agent.md](references/video-agent.md)
-3. `GET /v2/videos/<id>` — see [video-status.md](references/video-status.md)
-
-## Quick Reference
-
-| Task | MCP Tool | Read |
-|------|----------|------|
-| Generate video from prompt | `mcp__heygen__generate_video_agent` | [prompt-optimizer.md](references/prompt-optimizer.md) → [visual-styles.md](references/visual-styles.md) → [video-agent.md](references/video-agent.md) |
-| Check video status / get download URL | `mcp__heygen__get_video` | [video-status.md](references/video-status.md) |
-| Upload reference files for prompt | — | [assets.md](references/assets.md) |
-
-## When to Use This Skill vs Avatar Video
-
-This skill is for **prompt-based video creation** — describe what you want, and the AI handles the rest.
-
-If the user needs **precise control** over specific avatars, exact scripts, per-scene voice/background configuration, or multi-scene composition, use the **avatar-video** skill instead.
-
-| User Says | This Skill | Avatar Video Skill |
-|-----------|:----------:|:------------------:|
-| "Make me a video about X" | ✓ | |
-| "Create a product demo" | ✓ | |
-| "I want avatar Y to say exactly Z" | | ✓ |
-| "Multi-scene video with different backgrounds" | | ✓ |
-| "Transparent WebM for compositing" | | ✓ |
+2. `POST /v3/video-agents` — see [video-agent.md](references/video-agent.md)
+3. `GET /v3/videos/<id>` — see [video-status.md](references/video-status.md)
 
 ## Reference Files
 
-### Core Workflow
-- [references/prompt-optimizer.md](references/prompt-optimizer.md) - Writing effective prompts (core workflow + rules)
-- [references/visual-styles.md](references/visual-styles.md) - 20 named visual styles with full specs
-- [references/prompt-examples.md](references/prompt-examples.md) - Full production prompt example + ready-to-use templates
-- [references/video-agent.md](references/video-agent.md) - Video Agent API endpoint details
+Read these as needed — they contain endpoint details, request/response schemas, and code examples (curl, TypeScript, Python).
 
-### Foundation
-- [references/video-status.md](references/video-status.md) - Polling patterns and download URLs
-- [references/webhooks.md](references/webhooks.md) - Webhook endpoints and events
-- [references/assets.md](references/assets.md) - Uploading images, videos, audio as references
-- [references/dimensions.md](references/dimensions.md) - Resolution and aspect ratios
-- [references/quota.md](references/quota.md) - Credit system and usage limits
+**Core workflow:**
+- [references/prompt-optimizer.md](references/prompt-optimizer.md) — Writing effective prompts (scenes, timing, visual styles)
+- [references/visual-styles.md](references/visual-styles.md) — 20 named visual styles with full specs
+- [references/prompt-examples.md](references/prompt-examples.md) — Production prompt examples and templates
+- [references/video-agent.md](references/video-agent.md) — `POST /v3/video-agents` request fields, response format, file inputs
+
+**Foundation:**
+- [references/video-status.md](references/video-status.md) — `GET /v3/videos/{id}` polling and download
+- [references/webhooks.md](references/webhooks.md) — Webhook endpoints and events
+- [references/assets.md](references/assets.md) — Uploading images, videos, audio as references
+- [references/dimensions.md](references/dimensions.md) — Resolution and aspect ratios
+- [references/quota.md](references/quota.md) — Credit system and usage limits
 
 ## Best Practices
 
-1. **Optimize your prompt** — The difference between mediocre and professional results depends entirely on prompt quality. Always use the prompt optimizer
-2. **Specify duration** — Use `config.duration_sec` for predictable length
-3. **Lock avatar if needed** — Use `config.avatar_id` for consistency across videos
-4. **Upload reference files** — Help the agent understand your brand/product
-5. **Iterate on prompts** — Refine based on results; Video Agent is great for quick iterations
+1. **Optimize your prompt** — quality depends entirely on prompt structure. Always use the prompt optimizer
+2. **Lock avatar if needed** — pass `avatar_id` for consistency across videos
+3. **Specify voice** — pass `voice_id` for a specific narrator voice
+4. **Upload reference files** — help the agent understand your brand/product
+5. **Iterate on prompts** — refine based on results; Video Agent is great for quick iterations

--- a/skills/create-video/references/assets.md
+++ b/skills/create-video/references/assets.md
@@ -307,15 +307,21 @@ async function createVideoWithCustomBackground(
     dimension: { width: 1920, height: 1080 },
   };
 
-  // 3. Generate video
+  // 3. Generate video with Video Agent
   console.log("Generating video...");
-  const response = await fetch("https://api.heygen.com/v2/video/generate", {
+  const response = await fetch("https://api.heygen.com/v3/video-agents", {
     method: "POST",
     headers: {
       "X-Api-Key": process.env.HEYGEN_API_KEY!,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(config),
+    body: JSON.stringify({
+      prompt: "Create a product demo using the uploaded assets",
+      files: [
+        { type: "asset_id", asset_id: logoAssetId },
+        { type: "asset_id", asset_id: bgAssetId },
+      ],
+    }),
   });
 
   const { data } = await response.json();

--- a/skills/create-video/references/dimensions.md
+++ b/skills/create-video/references/dimensions.md
@@ -67,15 +67,12 @@ const squareConfig = {
 
 ```bash
 # Landscape 1080p
-curl -X POST "https://api.heygen.com/v2/video/generate" \
+curl -X POST "https://api.heygen.com/v3/video-agents" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "video_inputs": [...],
-    "dimension": {
-      "width": 1920,
-      "height": 1080
-    }
+    "prompt": "Create a product demo video.",
+    "orientation": "landscape"
   }'
 ```
 

--- a/skills/create-video/references/video-agent.md
+++ b/skills/create-video/references/video-agent.md
@@ -9,18 +9,18 @@ The Video Agent API generates complete videos from a single text prompt. Unlike 
 
 ## MCP Tool (Preferred)
 
-If the HeyGen MCP server is connected, use `mcp__heygen__generate_video_agent` instead of direct API calls:
+If the HeyGen MCP server is connected, use `mcp__heygen__create_video_agent` instead of direct API calls:
 
 ```
-Tool: mcp__heygen__generate_video_agent
+Tool: mcp__heygen__create_video_agent
 Parameters:
   prompt: "<optimized prompt from prompt-optimizer.md>"
-  config:
-    duration_sec: 90          # optional, 5-300
-    avatar_id: "avatar_id"    # optional, agent selects if omitted
-    orientation: "landscape"   # optional, "landscape" or "portrait"
-  files:                       # optional
-    - asset_id: "uploaded_asset_id"
+  avatar_id: "avatar_id"       # optional, agent selects if omitted
+  voice_id: "voice_id"         # optional, agent selects if omitted
+  orientation: "landscape"     # optional, "landscape" or "portrait"
+  files:                       # optional, type-discriminated union
+    - type: "asset_id"
+      asset_id: "uploaded_asset_id"
 ```
 
 Then check status with `mcp__heygen__get_video` using the returned `video_id`.
@@ -32,11 +32,11 @@ The prompt quality is still the critical factor — always follow [prompt-optimi
 | Use Case | Recommended API |
 |----------|-----------------|
 | Quick video from idea | Video Agent |
-| Precise control over scenes, avatars, timing | Standard v2/video/generate |
+| Precise control over scenes, avatars, timing | Standard POST /v3/videos |
 | Automated content generation at scale | Video Agent |
-| Specific avatar with exact script | Standard v2/video/generate |
+| Specific avatar with exact script | Standard POST /v3/videos |
 | Prototype or draft video | Video Agent |
-| Brand-consistent production video | Standard v2/video/generate |
+| Brand-consistent production video | Standard POST /v3/videos |
 
 ## Before You Call This API
 
@@ -51,40 +51,53 @@ Quick checklist:
 ## Direct API Endpoint
 
 ```
-POST https://api.heygen.com/v1/video_agent/generate
+POST https://api.heygen.com/v3/video-agents
 ```
 
 ## Request Fields
 
+All fields are top-level (no nested `config` object).
+
 | Field | Type | Req | Description |
 |-------|------|:---:|-------------|
-| `prompt` | string | ✓ | Text prompt describing the video you want |
-| `config` | object | | Configuration options (see below) |
-| `files` | array | | Asset files to reference in generation |
-| `callback_id` | string | | Custom ID for tracking. **Requires `callback_url` to also be set** — omit both if you don't need webhooks |
-| `callback_url` | string | | Webhook URL for completion notification |
-
-### Config Object
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `duration_sec` | integer | Approximate duration in seconds (5-300) |
-| `avatar_id` | string | Specific avatar to use (optional - agent selects if not provided) |
-| `orientation` | string | `"portrait"` or `"landscape"` |
+| `prompt` | string | ✓ | Text prompt describing the video you want (1-10000 chars) |
+| `avatar_id` | string \| null | | Specific avatar to use (agent selects if omitted) |
+| `voice_id` | string \| null | | Specific voice for narration (agent selects if omitted) |
+| `orientation` | string \| null | | `"landscape"` or `"portrait"` |
+| `files` | array \| null | | Asset files to reference in generation (max 20, see below) |
+| `callback_url` | string \| null | | Webhook URL for completion notification |
+| `callback_id` | string \| null | | Custom ID for tracking. **Requires `callback_url` to also be set** — omit both if you don't need webhooks |
 
 ### Files Array
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `asset_id` | string | Asset ID of uploaded file to reference |
+Each file entry is a type-discriminated union. You must include the `type` field to indicate the format.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `AssetUrl` | `{ type: "url", url: string }` | Public URL to a file |
+| `AssetId` | `{ type: "asset_id", asset_id: string }` | Asset ID of a previously uploaded file |
+| `AssetBase64` | `{ type: "base64", media_type: string, data: string }` | Inline base64-encoded file |
 
 ## Response Format
 
 ```json
 {
-  "error": null,
   "data": {
-    "video_id": "abc123"
+    "session_id": "sess_012abc345def678",
+    "status": "generating",
+    "video_id": "v_abc123def456",
+    "created_at": 1711929600
+  }
+}
+```
+
+**Error format:**
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "prompt is required"
   }
 }
 ```
@@ -92,7 +105,7 @@ POST https://api.heygen.com/v1/video_agent/generate
 ## curl Example
 
 ```bash
-curl -X POST "https://api.heygen.com/v1/video_agent/generate" \
+curl -X POST "https://api.heygen.com/v3/video-agents" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -103,43 +116,50 @@ curl -X POST "https://api.heygen.com/v1/video_agent/generate" \
 ## TypeScript
 
 ```typescript
-interface VideoAgentConfig {
-  duration_sec?: number;      // 5-300 seconds
-  avatar_id?: string;         // Optional: specific avatar
-  orientation?: "portrait" | "landscape";
-}
-
-interface VideoAgentFile {
-  asset_id: string;
-}
+type AssetUrl = { type: "url"; url: string };
+type AssetId = { type: "asset_id"; asset_id: string };
+type AssetBase64 = { type: "base64"; media_type: string; data: string };
+type VideoAgentFile = AssetUrl | AssetId | AssetBase64;
 
 interface VideoAgentRequest {
-  prompt: string;             // Required
-  config?: VideoAgentConfig;
-  files?: VideoAgentFile[];
-  callback_id?: string;       // Requires callback_url if set
-  callback_url?: string;
+  prompt: string;                              // Required, 1-10000 chars
+  avatar_id?: string | null;                   // Optional: specific avatar
+  voice_id?: string | null;                    // Optional: specific voice
+  orientation?: "portrait" | "landscape" | null;
+  files?: VideoAgentFile[] | null;             // Max 20 files
+  callback_id?: string | null;                 // Requires callback_url if set
+  callback_url?: string | null;
 }
 
 interface VideoAgentResponse {
-  error: string | null;
   data: {
+    session_id: string;
+    status: string;
     video_id: string;
+    created_at: number;
+  };
+}
+
+interface VideoAgentError {
+  error: {
+    code: string;
+    message: string;
   };
 }
 
 async function generateWithVideoAgent(
   prompt: string,
-  config?: VideoAgentConfig
-): Promise<string> {
-  const request: VideoAgentRequest = { prompt };
-
-  if (config) {
-    request.config = config;
+  options?: {
+    avatar_id?: string;
+    voice_id?: string;
+    orientation?: "portrait" | "landscape";
+    files?: VideoAgentFile[];
   }
+): Promise<{ session_id: string; video_id: string }> {
+  const request: VideoAgentRequest = { prompt, ...options };
 
   const response = await fetch(
-    "https://api.heygen.com/v1/video_agent/generate",
+    "https://api.heygen.com/v3/video-agents",
     {
       method: "POST",
       headers: {
@@ -150,13 +170,18 @@ async function generateWithVideoAgent(
     }
   );
 
-  const json: VideoAgentResponse = await response.json();
+  const json = await response.json();
 
-  if (json.error) {
-    throw new Error(`Video Agent failed: ${json.error}`);
+  if ("error" in json) {
+    const err = json as VideoAgentError;
+    throw new Error(`Video Agent failed: ${err.error.code} — ${err.error.message}`);
   }
 
-  return json.data.video_id;
+  const result = json as VideoAgentResponse;
+  return {
+    session_id: result.data.session_id,
+    video_id: result.data.video_id,
+  };
 }
 ```
 
@@ -169,37 +194,38 @@ from typing import Optional
 
 def generate_with_video_agent(
     prompt: str,
-    duration_sec: Optional[int] = None,
     avatar_id: Optional[str] = None,
-    orientation: Optional[str] = None
-) -> str:
-    request_body = {"prompt": prompt}
+    voice_id: Optional[str] = None,
+    orientation: Optional[str] = None,
+    files: Optional[list[dict]] = None,
+) -> dict:
+    """Returns dict with session_id, status, video_id, created_at."""
+    request_body: dict = {"prompt": prompt}
 
-    config = {}
-    if duration_sec:
-        config["duration_sec"] = duration_sec
     if avatar_id:
-        config["avatar_id"] = avatar_id
+        request_body["avatar_id"] = avatar_id
+    if voice_id:
+        request_body["voice_id"] = voice_id
     if orientation:
-        config["orientation"] = orientation
-
-    if config:
-        request_body["config"] = config
+        request_body["orientation"] = orientation
+    if files:
+        request_body["files"] = files
 
     response = requests.post(
-        "https://api.heygen.com/v1/video_agent/generate",
+        "https://api.heygen.com/v3/video-agents",
         headers={
             "X-Api-Key": os.environ["HEYGEN_API_KEY"],
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         },
-        json=request_body
+        json=request_body,
     )
 
     data = response.json()
-    if data.get("error"):
-        raise Exception(f"Video Agent failed: {data['error']}")
+    if "error" in data:
+        err = data["error"]
+        raise Exception(f"Video Agent failed: {err['code']} — {err['message']}")
 
-    return data["data"]["video_id"]
+    return data["data"]
 ```
 
 ## Examples
@@ -207,34 +233,85 @@ def generate_with_video_agent(
 ### Basic: Prompt Only
 
 ```typescript
-const videoId = await generateWithVideoAgent(
+const { video_id } = await generateWithVideoAgent(
   "Create a 30-second welcome video for new employees at a tech startup. Keep it energetic and modern."
 );
 ```
 
-### With Duration and Orientation
+```python
+result = generate_with_video_agent(
+    "Create a 30-second welcome video for new employees at a tech startup. Keep it energetic and modern."
+)
+video_id = result["video_id"]
+```
+
+```bash
+curl -X POST "https://api.heygen.com/v3/video-agents" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Create a 30-second welcome video for new employees at a tech startup. Keep it energetic and modern."
+  }'
+```
+
+### With Orientation
 
 ```typescript
-const videoId = await generateWithVideoAgent(
+const { video_id } = await generateWithVideoAgent(
   "Explain the benefits of cloud computing for small businesses. Use simple language and real-world examples.",
+  { orientation: "landscape" }
+);
+```
+
+```python
+result = generate_with_video_agent(
+    "Explain the benefits of cloud computing for small businesses. Use simple language and real-world examples.",
+    orientation="landscape",
+)
+```
+
+```bash
+curl -X POST "https://api.heygen.com/v3/video-agents" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Explain the benefits of cloud computing for small businesses. Use simple language and real-world examples.",
+    "orientation": "landscape"
+  }'
+```
+
+### With Specific Avatar and Voice
+
+```typescript
+const { video_id } = await generateWithVideoAgent(
+  "Present quarterly sales results. Professional tone, data-focused.",
   {
-    duration_sec: 90,
-    orientation: "landscape"
+    avatar_id: "josh_lite3_20230714",
+    voice_id: "1bd001e7e50f421d891986aad5158bc8",
+    orientation: "landscape",
   }
 );
 ```
 
-### With Specific Avatar
+```python
+result = generate_with_video_agent(
+    "Present quarterly sales results. Professional tone, data-focused.",
+    avatar_id="josh_lite3_20230714",
+    voice_id="1bd001e7e50f421d891986aad5158bc8",
+    orientation="landscape",
+)
+```
 
-```typescript
-const videoId = await generateWithVideoAgent(
-  "Present quarterly sales results. Professional tone, data-focused.",
-  {
-    duration_sec: 120,
-    avatar_id: "josh_lite3_20230714",
-    orientation: "landscape"
-  }
-);
+```bash
+curl -X POST "https://api.heygen.com/v3/video-agents" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Present quarterly sales results. Professional tone, data-focused.",
+    "avatar_id": "josh_lite3_20230714",
+    "voice_id": "1bd001e7e50f421d891986aad5158bc8",
+    "orientation": "landscape"
+  }'
 ```
 
 ### With Reference Files
@@ -247,27 +324,46 @@ const logoAssetId = await uploadFile("./company-logo.png", "image/png");
 const productImageId = await uploadFile("./product-screenshot.png", "image/png");
 
 // 2. Generate video with references
-const response = await fetch(
-  "https://api.heygen.com/v1/video_agent/generate",
+const { video_id } = await generateWithVideoAgent(
+  "Create a product demo video showcasing our new dashboard feature. Use the uploaded screenshots as visual references.",
   {
-    method: "POST",
-    headers: {
-      "X-Api-Key": process.env.HEYGEN_API_KEY!,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      prompt: "Create a product demo video showcasing our new dashboard feature. Use the uploaded screenshots as visual references.",
-      config: {
-        duration_sec: 60,
-        orientation: "landscape"
-      },
-      files: [
-        { asset_id: logoAssetId },
-        { asset_id: productImageId }
-      ]
-    }),
+    orientation: "landscape",
+    files: [
+      { type: "asset_id", asset_id: logoAssetId },
+      { type: "asset_id", asset_id: productImageId },
+    ],
   }
 );
+```
+
+```python
+# 1. Upload reference materials (see assets.md)
+logo_asset_id = upload_file("./company-logo.png", "image/png")
+product_image_id = upload_file("./product-screenshot.png", "image/png")
+
+# 2. Generate video with references
+result = generate_with_video_agent(
+    "Create a product demo video showcasing our new dashboard feature. Use the uploaded screenshots as visual references.",
+    orientation="landscape",
+    files=[
+        {"type": "asset_id", "asset_id": logo_asset_id},
+        {"type": "asset_id", "asset_id": product_image_id},
+    ],
+)
+```
+
+```bash
+curl -X POST "https://api.heygen.com/v3/video-agents" \
+  -H "X-Api-Key: $HEYGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Create a product demo video showcasing our new dashboard feature. Use the uploaded screenshots as visual references.",
+    "orientation": "landscape",
+    "files": [
+      { "type": "asset_id", "asset_id": "uploaded_logo_id" },
+      { "type": "url", "url": "https://example.com/product-screenshot.png" }
+    ]
+  }'
 ```
 
 ## Writing Effective Prompts
@@ -275,7 +371,7 @@ const response = await fetch(
 See **[prompt-optimizer.md](prompt-optimizer.md)** for comprehensive prompt writing guidance.
 
 The prompt optimizer covers:
-- Prompt complexity levels (basic → scene-by-scene)
+- Prompt complexity levels (basic -> scene-by-scene)
 - Visual style taxonomy and color specification
 - Media type selection (Motion Graphics vs Stock vs AI-generated)
 - Scene structure and timing calculations
@@ -283,28 +379,57 @@ The prompt optimizer covers:
 
 ## Checking Video Status
 
-Video Agent returns a `video_id` - use the standard status endpoint to check progress:
+Video Agent returns a `video_id` — use the standard status endpoint to check progress:
+
+```
+GET https://api.heygen.com/v3/videos/{video_id}
+```
 
 ```typescript
 // Same polling as standard video generation
 const videoUrl = await waitForVideo(videoId);
 ```
 
-See [video-status.md](video-status.md) for polling implementation.
+```python
+import time
+
+def wait_for_video(video_id: str, timeout: int = 600) -> str:
+    """Poll until video is ready. Returns the video URL."""
+    start = time.time()
+    while time.time() - start < timeout:
+        resp = requests.get(
+            f"https://api.heygen.com/v3/videos/{video_id}",
+            headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+        )
+        data = resp.json()["data"]
+        if data["status"] == "completed":
+            return data["video_url"]
+        if data["status"] == "failed":
+            raise Exception(f"Video failed: {data.get('error')}")
+        time.sleep(5)
+    raise TimeoutError(f"Video {video_id} did not complete within {timeout}s")
+```
+
+```bash
+curl "https://api.heygen.com/v3/videos/$VIDEO_ID" \
+  -H "X-Api-Key: $HEYGEN_API_KEY"
+```
+
+See [video-status.md](video-status.md) for full polling implementation.
 
 ## Comparison: Video Agent vs Standard API
 
 ### Video Agent Request
 ```typescript
 // Simple: describe what you want
-const videoId = await generateWithVideoAgent(
+const { video_id } = await generateWithVideoAgent(
   "Create a 60-second tutorial on setting up two-factor authentication. Professional tone, step-by-step."
 );
 ```
 
 ### Equivalent Standard API Request
 ```typescript
-// Complex: specify every detail
+// Complex: specify every detail via POST /v3/videos
 const videoId = await generateVideo({
   video_inputs: [
     {
@@ -331,17 +456,16 @@ const videoId = await generateVideo({
 
 ## Limitations
 
-- Less control over exact script wording
 - Avatar selection may vary if not specified
 - Scene composition is automated
 - May not match precise brand guidelines
-- Duration is approximate, not exact
+- Duration is approximate (determined by the agent from the prompt, not directly configurable)
 
 ## Best Practices
 
-1. **Be specific in prompts** - More detail = better results
-2. **Specify duration** - Use `config.duration_sec` for predictable length
-3. **Lock avatar if needed** - Use `config.avatar_id` for consistency
-4. **Upload reference files** - Help agent understand your brand/product
-5. **Iterate on prompts** - Refine based on results
-6. **Use for drafts** - Video Agent is great for quick iterations before final production
+1. **Be specific in prompts** — More detail = better results
+2. **Specify voice if needed** — Use `voice_id` to lock a specific voice for consistency
+3. **Lock avatar if needed** — Use `avatar_id` for consistency across videos
+4. **Upload reference files** — Help agent understand your brand/product (use `type: "asset_id"` for uploaded assets, `type: "url"` for public URLs)
+5. **Iterate on prompts** — Refine based on results
+6. **Use for drafts** — Video Agent is great for quick iterations before final production

--- a/skills/create-video/references/video-status.md
+++ b/skills/create-video/references/video-status.md
@@ -9,14 +9,14 @@ After generating a video, you need to poll for status until the video is complet
 
 ## MCP Tool (Preferred)
 
-If the HeyGen MCP server is connected, use `mcp__heygen__get_video` with the `videoId` parameter. It returns status, video_url, thumbnail_url, duration, title, gif_url, captioned_video_url, and other metadata in a single call.
+If the HeyGen MCP server is connected, use `mcp__heygen__get_video` with the `videoId` parameter. It returns status, video_url, thumbnail_url, duration, title, gif_url, captioned_video_url, video_page_url, and other metadata in a single call.
 
 ## Checking Video Status (Direct API)
 
 ### curl
 
 ```bash
-curl -X GET "https://api.heygen.com/v2/videos/YOUR_VIDEO_ID" \
+curl -X GET "https://api.heygen.com/v3/videos/YOUR_VIDEO_ID" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
@@ -24,7 +24,6 @@ curl -X GET "https://api.heygen.com/v2/videos/YOUR_VIDEO_ID" \
 
 ```typescript
 interface VideoStatusResponse {
-  error: null | string;
   data: {
     id: string;
     status: "pending" | "processing" | "completed" | "failed";
@@ -32,28 +31,33 @@ interface VideoStatusResponse {
     thumbnail_url?: string;
     duration?: number;
     title?: string;
-    created_at?: string;
-    completed_at?: string;
+    created_at?: number;
+    completed_at?: number;
     gif_url?: string;
     captioned_video_url?: string;
     subtitle_url?: string;
     folder_id?: string;
     output_language?: string;
+    video_page_url?: string;
     failure_code?: string;
     failure_message?: string;
+  };
+  error?: {
+    code: string;
+    message: string;
   };
 }
 
 async function getVideoStatus(videoId: string): Promise<VideoStatusResponse["data"]> {
   const response = await fetch(
-    `https://api.heygen.com/v2/videos/${videoId}`,
+    `https://api.heygen.com/v3/videos/${videoId}`,
     { headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! } }
   );
 
   const json: VideoStatusResponse = await response.json();
 
   if (json.error) {
-    throw new Error(json.error);
+    throw new Error(`${json.error.code}: ${json.error.message}`);
   }
 
   return json.data;
@@ -68,13 +72,14 @@ import os
 
 def get_video_status(video_id: str) -> dict:
     response = requests.get(
-        f"https://api.heygen.com/v2/videos/{video_id}",
+        f"https://api.heygen.com/v3/videos/{video_id}",
         headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]}
     )
 
     data = response.json()
     if data.get("error"):
-        raise Exception(data["error"])
+        err = data["error"]
+        raise Exception(f"{err['code']}: {err['message']}")
 
     return data["data"]
 ```
@@ -111,7 +116,6 @@ Video generation typically takes **5-15 minutes**, but can exceed 20 minutes dur
 
 ```json
 {
-  "error": null,
   "data": {
     "id": "abc123",
     "status": "completed",
@@ -119,13 +123,14 @@ Video generation typically takes **5-15 minutes**, but can exceed 20 minutes dur
     "thumbnail_url": "https://files.heygen.ai/thumbnail/abc123.jpg",
     "duration": 45.2,
     "title": "My Video",
-    "created_at": "2024-01-15T10:30:00Z",
-    "completed_at": "2024-01-15T10:38:00Z",
+    "created_at": 1705311000,
+    "completed_at": 1705311480,
     "gif_url": "https://files.heygen.ai/gif/abc123.gif",
     "captioned_video_url": null,
     "subtitle_url": null,
     "folder_id": null,
-    "output_language": "en"
+    "output_language": "en",
+    "video_page_url": "https://app.heygen.com/videos/abc123"
   }
 }
 ```
@@ -134,12 +139,22 @@ Video generation typically takes **5-15 minutes**, but can exceed 20 minutes dur
 
 ```json
 {
-  "error": null,
   "data": {
     "id": "abc123",
     "status": "failed",
     "failure_code": "script_too_long",
     "failure_message": "Script too long for selected avatar"
+  }
+}
+```
+
+### Error Response
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Video not found"
   }
 }
 ```
@@ -352,7 +367,7 @@ async function downloadVideo(videoUrl: string, outputPath = "./output/video.mp4"
 async function generateAndDownloadVideo(config: VideoConfig): Promise<string> {
   // 1. Generate video
   const generateResponse = await fetch(
-    "https://api.heygen.com/v2/video/generate",
+    "https://api.heygen.com/v3/videos",
     {
       method: "POST",
       headers: {
@@ -363,8 +378,11 @@ async function generateAndDownloadVideo(config: VideoConfig): Promise<string> {
     }
   );
 
-  const { data: generateData } = await generateResponse.json();
-  const videoId = generateData.video_id;
+  const generateJson = await generateResponse.json();
+  if (generateJson.error) {
+    throw new Error(`${generateJson.error.code}: ${generateJson.error.message}`);
+  }
+  const videoId = generateJson.data.video_id;
   console.log(`Video ID: ${videoId}`);
 
   // 2. Poll for completion
@@ -440,6 +458,7 @@ async function checkVideoStatus(): Promise<void> {
     case "completed":
       console.log(`Video ready: ${status.video_url}`);
       console.log(`Duration: ${status.duration}s`);
+      console.log(`Video page: ${status.video_page_url}`);
       // Clean up pending file
       fs.unlinkSync("pending-video.json");
       // Save result
@@ -451,6 +470,7 @@ async function checkVideoStatus(): Promise<void> {
         title: status.title,
         createdAt: status.created_at,
         completedAt: status.completed_at,
+        videoPageUrl: status.video_page_url,
       }, null, 2));
       break;
     case "failed":

--- a/skills/text-to-speech/SKILL.md
+++ b/skills/text-to-speech/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: text-to-speech
 description: |
-  Generate speech audio from text using HeyGen's Starfish TTS model. Use when: (1) Generating standalone speech audio files from text, (2) Converting text to speech with voice selection, speed, and pitch control, (3) Creating audio for voiceovers, narration, or podcasts, (4) Working with HeyGen's /v1/audio endpoints, (5) Listing available TTS voices by language or gender.
+  Generate speech audio from text using HeyGen's Starfish TTS model. Use when: (1) Generating standalone speech audio files from text, (2) Converting text to speech with voice selection and speed control, (3) Creating audio for voiceovers, narration, or podcasts, (4) Working with HeyGen's /v3/voices endpoints, (5) Listing available TTS voices by language or gender.
 allowed-tools: mcp__heygen__*
 metadata:
   openclaw:
@@ -13,14 +13,14 @@ metadata:
 
 # Text-to-Speech (HeyGen Starfish)
 
-Generate speech audio files from text using HeyGen's in-house Starfish TTS model. This skill is for standalone audio generation — separate from video creation.
+Generate speech audio files from text using HeyGen's in-house Starfish TTS model via the v3 API. This skill is for standalone audio generation — separate from video creation.
 
 ## Authentication
 
 All requests require the `X-Api-Key` header. Set the `HEYGEN_API_KEY` environment variable.
 
 ```bash
-curl -X GET "https://api.heygen.com/v1/audio/voices" \
+curl -X GET "https://api.heygen.com/v3/voices?engine=starfish" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
@@ -30,37 +30,48 @@ If HeyGen MCP tools are available (`mcp__heygen__*`), **prefer them** over direc
 
 | Task | MCP Tool | Fallback (Direct API) |
 |------|----------|----------------------|
-| List TTS voices | `mcp__heygen__list_audio_voices` | `GET /v1/audio/voices` |
-| Generate speech audio | `mcp__heygen__text_to_speech` | `POST /v1/audio/text_to_speech` |
+| List TTS voices | `mcp__heygen__list_audio_voices` | `GET /v3/voices?engine=starfish` |
+| Generate speech audio | `mcp__heygen__text_to_speech` | `POST /v3/voices/speech` |
 
 ## Default Workflow
 
-1. List voices with `mcp__heygen__list_audio_voices` (or `GET /v1/audio/voices`)
+1. List voices with `mcp__heygen__list_audio_voices` (or `GET /v3/voices?engine=starfish`)
 2. Pick a voice matching desired language, gender, and features
-3. Call `mcp__heygen__text_to_speech` (or `POST /v1/audio/text_to_speech`) with text and voice_id
+3. Call `mcp__heygen__text_to_speech` (or `POST /v3/voices/speech`) with text and voice_id
 4. Use the returned `audio_url` to download or play the audio
 
 ## List TTS Voices
 
 Retrieve voices compatible with the Starfish TTS model.
 
-> **Note:** This uses `GET /v1/audio/voices` — a different endpoint from the video voices API (`GET /v2/voices`). Not all video voices support Starfish TTS.
+> **Note:** This uses the unified `GET /v3/voices` endpoint with the `engine=starfish` filter to return only TTS-compatible voices. Not all video voices support Starfish TTS. The response is paginated — use `next_token` to fetch additional pages.
+
+### Query Parameters
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `engine` | string | Filter by engine (use `starfish` for TTS voices) |
+| `type` | string | `public` or `private` |
+| `language` | string | Filter by language |
+| `gender` | string | Filter by gender |
+| `limit` | integer | Results per page, 1-100 |
+| `token` | string | Pagination cursor from `next_token` |
 
 ### curl
 
 ```bash
-curl -X GET "https://api.heygen.com/v1/audio/voices" \
+curl -X GET "https://api.heygen.com/v3/voices?engine=starfish" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
 ### TypeScript
 
 ```typescript
-interface TTSVoice {
+interface AudioVoiceItem {
   voice_id: string;
+  name: string;
   language: string;
   gender: "female" | "male" | "unknown";
-  name: string;
   preview_audio_url: string | null;
   support_pause: boolean;
   support_locale: boolean;
@@ -69,23 +80,35 @@ interface TTSVoice {
 
 interface TTSVoicesResponse {
   error: null | string;
-  data: {
-    voices: TTSVoice[];
-  };
+  data: AudioVoiceItem[];
+  has_more: boolean;
+  next_token: string | null;
 }
 
-async function listTTSVoices(): Promise<TTSVoice[]> {
-  const response = await fetch("https://api.heygen.com/v1/audio/voices", {
-    headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
-  });
+async function listTTSVoices(): Promise<AudioVoiceItem[]> {
+  const allVoices: AudioVoiceItem[] = [];
+  let token: string | null = null;
 
-  const json: TTSVoicesResponse = await response.json();
+  do {
+    const url = new URL("https://api.heygen.com/v3/voices");
+    url.searchParams.set("engine", "starfish");
+    if (token) url.searchParams.set("token", token);
 
-  if (json.error) {
-    throw new Error(json.error);
-  }
+    const response = await fetch(url.toString(), {
+      headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
+    });
 
-  return json.data.voices;
+    const json: TTSVoicesResponse = await response.json();
+
+    if (json.error) {
+      throw new Error(json.error);
+    }
+
+    allVoices.push(...json.data);
+    token = json.next_token;
+  } while (token);
+
+  return allVoices;
 }
 ```
 
@@ -96,16 +119,31 @@ import requests
 import os
 
 def list_tts_voices() -> list:
-    response = requests.get(
-        "https://api.heygen.com/v1/audio/voices",
-        headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]}
-    )
+    all_voices = []
+    token = None
 
-    data = response.json()
-    if data.get("error"):
-        raise Exception(data["error"])
+    while True:
+        params = {"engine": "starfish"}
+        if token:
+            params["token"] = token
 
-    return data["data"]["voices"]
+        response = requests.get(
+            "https://api.heygen.com/v3/voices",
+            headers={"X-Api-Key": os.environ["HEYGEN_API_KEY"]},
+            params=params,
+        )
+
+        data = response.json()
+        if data.get("error"):
+            raise Exception(data["error"])
+
+        all_voices.extend(data["data"])
+
+        if not data.get("has_more"):
+            break
+        token = data.get("next_token")
+
+    return all_voices
 ```
 
 ### Response Format
@@ -113,20 +151,20 @@ def list_tts_voices() -> list:
 ```json
 {
   "error": null,
-  "data": {
-    "voices": [
-      {
-        "voice_id": "f38a635bee7a4d1f9b0a654a31d050d2",
-        "name": "Chill Brian",
-        "language": "English",
-        "gender": "male",
-        "preview_audio_url": "https://resource.heygen.ai/text_to_speech/WpSDQvmLGXEqXZVZQiVeg6.mp3",
-        "support_pause": true,
-        "support_locale": false,
-        "type": "public"
-      }
-    ]
-  }
+  "data": [
+    {
+      "voice_id": "f38a635bee7a4d1f9b0a654a31d050d2",
+      "name": "Chill Brian",
+      "language": "English",
+      "gender": "male",
+      "preview_audio_url": "https://resource.heygen.ai/text_to_speech/WpSDQvmLGXEqXZVZQiVeg6.mp3",
+      "support_pause": true,
+      "support_locale": false,
+      "type": "public"
+    }
+  ],
+  "has_more": false,
+  "next_token": null
 }
 ```
 
@@ -136,32 +174,23 @@ Convert text to speech audio using a specified voice.
 
 ### Endpoint
 
-`POST https://api.heygen.com/v1/audio/text_to_speech`
+`POST https://api.heygen.com/v3/voices/speech`
 
 ### Request Fields
 
 | Field | Type | Req | Description |
 |-------|------|:---:|-------------|
-| `text` | string | Y | Text content to convert to speech |
-| `voice_id` | string | Y | Voice ID from `GET /v1/audio/voices` |
-| `speed` | number | | Speech speed, 0.5-1.5 (default: 1) |
-| `pitch` | integer | | Voice pitch, -50 to 50 (default: 0) |
-| `locale` | string | | Accent/locale for multilingual voices (e.g., `en-US`, `pt-BR`) |
-| `elevenlabs_settings` | object | | Advanced settings for ElevenLabs voices |
-
-### ElevenLabs Settings (optional)
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `model` | string | Model selection (`eleven_v3`, `eleven_turbo_v2_5`, etc.) |
-| `similarity_boost` | number | Voice similarity, 0.0-1.0 |
-| `stability` | number | Output consistency, 0.0-1.0 |
-| `style` | number | Style intensity, 0.0-1.0 |
+| `text` | string | Y | Text content to convert (1-5000 characters) |
+| `voice_id` | string | Y | Voice ID from `GET /v3/voices?engine=starfish` |
+| `input_type` | string | | `"text"` (default) or `"ssml"` for full SSML markup |
+| `speed` | number | | Speech speed, 0.5-2.0 (default: 1.0) |
+| `language` | string | | Base language code (e.g., `"en"`, `"pt"`). Auto-detected if omitted |
+| `locale` | string | | BCP-47 locale for multilingual voices (e.g., `"en-US"`, `"pt-BR"`) |
 
 ### curl
 
 ```bash
-curl -X POST "https://api.heygen.com/v1/audio/text_to_speech" \
+curl -X POST "https://api.heygen.com/v3/voices/speech" \
   -H "X-Api-Key: $HEYGEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -177,15 +206,10 @@ curl -X POST "https://api.heygen.com/v1/audio/text_to_speech" \
 interface TTSRequest {
   text: string;
   voice_id: string;
+  input_type?: "text" | "ssml";
   speed?: number;
-  pitch?: number;
+  language?: string;
   locale?: string;
-  elevenlabs_settings?: {
-    model?: string;
-    similarity_boost?: number;
-    stability?: number;
-    style?: number;
-  };
 }
 
 interface WordTimestamp {
@@ -199,14 +223,14 @@ interface TTSResponse {
   data: {
     audio_url: string;
     duration: number;
-    request_id: string;
-    word_timestamps: WordTimestamp[];
+    request_id?: string;
+    word_timestamps?: WordTimestamp[];
   };
 }
 
 async function textToSpeech(request: TTSRequest): Promise<TTSResponse["data"]> {
   const response = await fetch(
-    "https://api.heygen.com/v1/audio/text_to_speech",
+    "https://api.heygen.com/v3/voices/speech",
     {
       method: "POST",
       headers: {
@@ -236,22 +260,28 @@ import os
 def text_to_speech(
     text: str,
     voice_id: str,
+    input_type: str = "text",
     speed: float = 1.0,
-    pitch: int = 0,
+    language: str | None = None,
     locale: str | None = None,
 ) -> dict:
     payload = {
         "text": text,
         "voice_id": voice_id,
         "speed": speed,
-        "pitch": pitch,
     }
+
+    if input_type != "text":
+        payload["input_type"] = input_type
+
+    if language:
+        payload["language"] = language
 
     if locale:
         payload["locale"] = locale
 
     response = requests.post(
-        "https://api.heygen.com/v1/audio/text_to_speech",
+        "https://api.heygen.com/v3/voices/speech",
         headers={
             "X-Api-Key": os.environ["HEYGEN_API_KEY"],
             "Content-Type": "application/json",
@@ -309,13 +339,24 @@ const result = await textToSpeech({
 });
 ```
 
-### With Locale for Multilingual Voices
+### With Language and Locale for Multilingual Voices
 
 ```typescript
 const result = await textToSpeech({
   text: "Bem-vindo ao nosso produto.",
   voice_id: "MULTILINGUAL_VOICE_ID",
+  language: "pt",
   locale: "pt-BR",
+});
+```
+
+### With SSML Input
+
+```typescript
+const result = await textToSpeech({
+  text: '<speak>Hello <break time="1s"/> and welcome!</speak>',
+  voice_id: "YOUR_VOICE_ID",
+  input_type: "ssml",
 });
 ```
 
@@ -356,11 +397,23 @@ Rules:
 - Must have spaces before and after the tag
 - Self-closing tag format
 
+With v3, you can also use `input_type: "ssml"` for full SSML support, allowing richer markup beyond just break tags:
+
+```json
+{
+  "text": "<speak>Welcome! <break time=\"1s\"/> Let's get started.</speak>",
+  "voice_id": "YOUR_VOICE_ID",
+  "input_type": "ssml"
+}
+```
+
 ## Best Practices
 
-1. **Use `GET /v1/audio/voices`** to find compatible voices — not all voices from `GET /v2/voices` support Starfish TTS
+1. **Use `GET /v3/voices?engine=starfish`** to find compatible voices — the unified `/v3/voices` endpoint serves all voice types, so the `engine=starfish` filter is essential for TTS
 2. **Check `support_locale`** before setting a `locale` — only multilingual voices support locale selection
 3. **Keep speed between 0.8-1.2** for natural-sounding output
 4. **Preview voices** using the `preview_audio_url` before generating (may be null for some voices)
 5. **Use `word_timestamps`** in the response for caption syncing or timed text overlays
 6. **Use SSML break tags** in your text for pauses: `word <break time="1s"/> word`
+7. **Use `input_type: "ssml"`** when you need full SSML markup control beyond simple break tags
+8. **Paginate voice listing** — the v3 endpoint returns paginated results; use `has_more` and `next_token` to fetch all voices


### PR DESCRIPTION
## Summary

Migrates the public HeyGen skills from v1/v2 API endpoints to v3, addressing internal feedback about poor quality when using raw photos as v2 talking avatars.

- **avatar-video**: `POST /v3/videos` with discriminated union (`type="avatar"` for library avatars, `type="image"` + nested AssetInput for photo animation via Avatar IV). Avatars use new Groups + Looks model (`GET /v3/avatars`, `GET /v3/avatars/looks`). Voices use unified `GET /v3/voices` with server-side filtering.
- **create-video**: `POST /v3/video-agents` with flat structure (no nested config object), new `voice_id` field, type-discriminated file inputs.
- **text-to-speech**: `GET /v3/voices?engine=starfish` (unified voice endpoint) and `POST /v3/voices/speech` (new `input_type` for SSML support).
- **video-translate**, **faceswap**, **ai-video-gen**: No changes (no v3 equivalents).

## Testing

All v3 endpoints verified end-to-end against production API with a temporary API key:

| Endpoint | Status |
|----------|--------|
| `GET /v3/avatars` | Pass |
| `GET /v3/avatars/looks` | Pass |
| `GET /v3/avatars/looks/{id}` | Pass |
| `GET /v3/voices` | Pass |
| `GET /v3/voices?engine=starfish` | Pass |
| `POST /v3/voices/speech` | Pass |
| `POST /v3/video-agents` | Pass |
| `POST /v3/videos` (type=avatar) | Pass |
| `POST /v3/videos` (type=image) | Pass |
| `GET /v3/videos/{id}` | Pass |
| `GET /v3/videos` | Pass |
| `DELETE /v3/videos/{id}` | Pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)