### PR TITLE
Add reference to skills-legacy for v1 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ One optional shell script:
 
 Data only leaves your machine to `api.heygen.com` (video generation) and optionally `raw.githubusercontent.com` (version check).
 
+## Looking for the v1 skills?
+
+The previous version of this repo had individual skills for TTS, video translation, faceswap, video editing, and more. Those skills are preserved at [heygen-com/skills-legacy](https://github.com/heygen-com/skills-legacy).
+
 ## Links
 
 - [HeyGen API Docs](https://developers.heygen.com/docs/quick-start)


### PR DESCRIPTION
## Summary
- Adds a small section near the bottom of the README pointing people to `heygen-com/skills-legacy` if they're looking for the old v1 skills (TTS, video translate, faceswap, video editing, etc.)

## Test plan
- [ ] Verify the link renders correctly on GitHub
- [ ] Confirm the section placement feels natural (above Links, below Security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)