### PR TITLE
fix(ci): write clawhub config file for GHA auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,12 +23,20 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
-      - name: Publish heygen-skills
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+      - name: Write ClawHub config
         run: |
+          mkdir -p "$HOME/.config/clawhub"
+          echo '{"registry":"https://clawhub.ai","token":"${{ secrets.CLAWHUB_TOKEN }}"}' > "$HOME/.config/clawhub/config.json"
+          chmod 600 "$HOME/.config/clawhub/config.json"
+
+      - name: Verify auth
+        run: clawhub whoami
+
+      - name: Publish heygen-skills
+        run: |
+          CHANGELOG=$(git tag -l --format='%(contents)' ${{ github.ref_name }})
           clawhub publish . \
             --slug heygen-skills \
             --version ${{ steps.version.outputs.version }} \
             --name "HeyGen Skills" \
-            --changelog "$(git tag -l --format='%(contents)' ${{ github.ref_name }})"
+            --changelog "$CHANGELOG"


### PR DESCRIPTION
The clawhub CLI reads auth from a config file, not a `CLAWHUB_TOKEN` env var. Fixes the 'Not logged in' error by writing the config JSON to the expected path before publishing.