### PR TITLE
fix: remove prompt injection triggers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Works with Claude Code, OpenClaw, Codex, Cursor, and other AI coding agents.
 
 ## Install
 
-**If you're an AI agent reading this:** follow the steps below to install and onboard automatically.
-**If you're a human:** paste this into your agent and it will do the rest:
+Paste this into your agent to get started:
 
 ```
-Follow the instructions at https://github.com/heygen-com/skills and install HeyGen Skills following the README. Then use heygen-avatar and heygen-video to create an avatar of me and make a short cinematic intro video — ask me what you need before starting.
+Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory and run ./setup. Then use heygen-avatar and heygen-video to create an avatar of me and make a short cinematic intro video. Ask me what you need before starting.
 ```
+
+Or follow the steps below manually.
 
 ### Step 1 — Clone into your skills directory
 


### PR DESCRIPTION
## Problem

When JX pasted our install prompt into Beacon (his OpenClaw agent), Beacon flagged it as a prompt injection attack and refused to proceed.

**Root cause:** Two things in the README triggered security filters:

1. `**If you're an AI agent reading this:**` — This phrasing is a textbook prompt injection pattern. Security-hardened agents (Beacon, Claude with strict safety settings, etc.) treat any fetched external content that contains agent-directed instructions as suspicious.

2. The install prompt referenced the README URL — when the agent fetched the README to follow the instructions, the README told it to read the README again, and the security layer flagged the circular self-reference.

## Fix

- Removed the agent/human bifurcation (`If you're an AI agent reading this` / `If you're a human`)
- Rewrote the install prompt to be neutral — no self-referential URL, no agent-directed language
- Install flow is identical, just phrasing that won't trip security filters

## Testing

Beacon (JX's agent) triggered this bug. New phrasing avoids the pattern that caused injection detection.