### PR TITLE
fix: prevent batch-asking and fix agent onboarding flow

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -98,6 +98,8 @@ Every command supports `--help`. Full reference: [../references/api-reference.md
 2. **No internal jargon.** Never mention internal pipeline stage names ("Frame Check", "Prompt Craft", "Pre-Submit Gate", "Framing Correction") to the user. These are internal pipeline stages. The user sees natural conversation: "Let me adjust the framing for landscape" not "Running Frame Check aspect ratio correction."
 3. **Polling is silent.** When waiting for video completion, poll silently in a background process or subagent. Do NOT send repeated "Checking status..." messages. Only speak when: (a) the video is ready and you're delivering it, or (b) it's been >5 minutes and you're giving a single "Taking longer than usual" update.
 4. **Deliver clean.** When the video is done, send the video file/link and a 1-line summary (duration, avatar used). Not a dump of every API field.
+5. **Don't batch-ask across skills.** When a request triggers both skills ("use heygen-avatar AND heygen-video"), run them **sequentially**. Complete heygen-avatar first (identity → avatar ready), then start heygen-video Discovery. Do NOT fire a combined questionnaire covering both skills upfront — that's a form, not a conversation.
+6. **Read workspace files before asking.** `SOUL.md`, `IDENTITY.md`, and `AVATAR-<NAME>.md` at the workspace root contain identity and existing avatar state. Check them first. Only ask the user for what's genuinely missing.
 
 ---
 

--- a/heygen-avatar/SKILL.md
+++ b/heygen-avatar/SKILL.md
@@ -23,6 +23,14 @@ allowed-tools: Bash, WebFetch, Read, Write, mcp__heygen__*
 
 Create and manage HeyGen avatars for anyone: the agent, the user, or named characters. Handles identity extraction, avatar generation, voice selection, and saves everything to `AVATAR-<NAME>.md` for consistent reuse.
 
+## Start Here (Critical)
+
+**Do NOT batch-ask questions.** Do not fire "give me a photo, voice preference, duration, target platform, tone, key message" all at once. Walk phases in order. Each phase asks at most one or two things at a time.
+
+**When creating for the agent itself** ("create your avatar", "bring yourself to life"), do NOT ask the user for a photo or appearance details first. Read `SOUL.md` and `IDENTITY.md` from the workspace root. The agent's identity lives there. Only ask the user for traits that are genuinely missing from those files.
+
+**Photo is a nudge, not a gate.** Prompt-based avatars work. Offer photo as an optional upgrade for face consistency across videos, not as a required input.
+
 ## Before You Start (Claude Code only)
 
 Try to read `SOUL.md` from the workspace root.
@@ -112,40 +120,50 @@ Start every invocation with:
 
 ## Workflow
 
+**DO NOT batch-ask questions upfront.** Walk phases in order. Each phase asks at most one thing at a time, and only if needed.
+
 ### Phase 0 — Who Are We Creating?
 
-Determine the target identity:
+Determine the target identity from the request. Do NOT ask the user "whose avatar?" if it's clear from phrasing:
 
-1. **Agent** — user says "create your avatar", "bring yourself to life" → read IDENTITY.md for name, then check `AVATAR-<NAME>.md`. If IDENTITY.md is not found (Claude Code environment), walk the user through designing from scratch with a few quick questions about appearance and voice.
-2. **User** — user says "create my avatar", "make me an avatar" → ask for their name, check `AVATAR-<NAME>.md`
-3. **Named character** — user says "create an avatar called Cleo" → check `AVATAR-CLEO.md`
+1. **Agent** — "create your avatar", "bring yourself to life", "design an avatar for you" → this is for the agent (Adam, Eve, Claude, etc.). Read `IDENTITY.md` for name.
+2. **User** — "create my avatar", "make me an avatar", "I want my face in a video" → for the user. Ask for their name if not obvious.
+3. **Named character** — "create an avatar called Cleo", "design a character named X" → use the given name.
 
-If the AVATAR file exists and has a HeyGen section filled in:
-> "You already have an avatar set up. Want to add a new look, update it, or start fresh?"
+Then check `AVATAR-<NAME>.md` at the workspace root:
 
-If the AVATAR file exists but HeyGen section is empty: proceed to Reference Photo Nudge.
-If no AVATAR file exists: proceed to Phase 1.
-
-### Reference Photo Nudge (First-Time Only)
-
-Before generating anything, ask if they have a reference image. Photo avatars produce significantly better face consistency across videos than prompt-generated ones.
-
-Ask if they have a reference photo, explaining that a headshot or clear face photo gives much better results than text-only generation. Offer to skip for prompt-based creation. Communicate in `user_language`.
-
-This applies to ALL targets (agent, user, named character). For agents, check if a reference photo path already exists in the AVATAR file's Appearance section or in IDENTITY.md before asking.
-
-- **Photo provided** → upload via `heygen asset create --file <path>` (or MCP equivalent), then use Type B (photo) creation in Phase 2
-- **Skip** → use Type A (prompt) creation in Phase 2
+- **AVATAR file exists + HeyGen section filled in** → "You already have an avatar set up. Want to add a new look, update it, or start fresh?" Wait for answer.
+- **AVATAR file exists but HeyGen section empty** → skip to Phase 2.
+- **No AVATAR file** → proceed to Phase 1.
 
 ### Phase 1 — Identity Extraction
 
-**For the agent:** Try to read `SOUL.md`, `IDENTITY.md`, and existing `AVATAR-<NAME>.md` from the workspace. If found, extract appearance and voice traits automatically. If not found (e.g. Claude Code environment), skip to conversational onboarding — ask the user to describe the agent's appearance and voice instead.
+**Order matters. Files first, questions second.**
 
-**For users/named characters:** Conversational onboarding. Ask naturally about their appearance (age, hair, general vibe) and voice (calm, energetic, accent). Not as a form — be conversational. Communicate in `user_language`.
+**For the agent** (Phase 0 target = agent):
+1. Read `SOUL.md`, `IDENTITY.md`, and any existing `AVATAR-<NAME>.md` from the workspace root.
+2. If SOUL.md or IDENTITY.md is found → extract appearance and voice traits silently. Do NOT ask the user "describe your appearance" — the agent IS the subject, and its identity lives in those files. **If the files describe only personality / values with no physical description, do NOT hallucinate traits.** Ask the user conversationally for the missing appearance traits only.
+3. If neither file is found (e.g., Claude Code environment with no workspace identity) → ask the user to describe the agent's appearance and voice conversationally.
 
-Write `AVATAR-<NAME>.md` with the Appearance and Voice sections filled in. Leave HeyGen section empty.
+**For users/named characters** (Phase 0 target = user or named):
+- Conversational onboarding. Ask naturally about appearance (age, hair, general vibe) and voice (calm/energetic, accent). Not as a form — one or two questions at a time. Communicate in `user_language`.
 
-Then proceed to the **Reference Photo Nudge** before Phase 2.
+Write `AVATAR-<NAME>.md` with the Appearance and Voice sections filled in. Leave the HeyGen section empty until Phase 2 succeeds.
+
+Then proceed to Phase 2 via the Reference Photo Nudge.
+
+### Reference Photo Nudge (Phase 2 entry)
+
+Ask if they have a reference photo. A photo produces better face consistency across videos, but prompt-based avatars work well when no photo is available. **This is a nudge, not a gate — offer to skip.**
+
+Check first:
+- **For agents:** look at the AVATAR file's Appearance → Reference field, or IDENTITY.md for a photo path. If found, skip asking and use it.
+- **For users:** ask. Keep it one sentence: "Got a headshot? It gives better face consistency, but I can also generate from your description — just say 'skip.'"
+
+Branch:
+- **Photo provided** → upload via MCP `upload_asset` or `heygen asset create --file <path>`, then Type B (photo) creation in Phase 2.
+- **Skip** → Type A (prompt) creation in Phase 2.
+
 
 ### Phase 2 — Avatar Creation
 

--- a/heygen-video/SKILL.md
+++ b/heygen-video/SKILL.md
@@ -82,6 +82,8 @@ Default to Full Producer. Better to ask one smart question than generate a medio
 
 Interview the user. Be conversational, skip anything already answered.
 
+**DO NOT batch-ask all of these at once.** Ask one or two items at a time. Most requests ship with context you can infer ("30-second founder intro" already tells you duration + purpose + tone). Only ask what's genuinely missing. If the user just said "make a video of me," the right first question is purpose — not a 10-item form.
+
 **Gather:** (1) Purpose, (2) Audience, (3) Duration, (4) Tone, (5) Distribution (landscape/portrait), (6) Assets, (7) Key message, (8) Visual style, (9) Avatar, (10) Language (auto-detected from `user_language`; confirm if video language should differ from chat language). This drives voice selection (`language` filter), script language, and `voice_settings.locale`.
 
 ### Assets


### PR DESCRIPTION
## Problem

When a user asks an agent to use both skills together ("use heygen-avatar and heygen-video"), the agent fires a 7-item questionnaire upfront instead of walking phases.

**Adam's observed response:**
```
For the avatar:
1. Photo — got a headshot? Photo-based avatars are significantly better than AI-generated ones.
2. Voice — want me to find matching voices or do you have a preference?

For the video:
3. What's it for? 4. Duration? 5. Where's it going? 6. Tone/vibe? 7. Key message?
```

Three bugs:

### 1. Skipped agent-identity path
When the ask was "create your avatar" (for the agent itself), the agent should read `SOUL.md` / `IDENTITY.md` first and extract traits silently. It was jumping straight to "give me a photo."

### 2. Reference photo framed as a gate
SKILL.md says "offer to skip for prompt-based creation" — prompt-based avatars work well. Adam framed it as "photo-based are significantly better than AI-generated," which overstates the SKILL's actual guidance ("better face consistency") and pressures the user into the photo path.

### 3. Batch interrogation
heygen-video's Discovery phase says "Be conversational, skip anything already answered" but Adam fired all 7 items upfront as a structured form.

## Fix

**Prompt-only** changes (no API/behavioral changes):

### SKILL.md (root)
Added UX Rules #5 and #6:
- **#5 Don't batch-ask across skills** — chain triggers run heygen-avatar **then** heygen-video sequentially, not in parallel with one combined questionnaire.
- **#6 Read workspace files before asking** — check SOUL.md, IDENTITY.md, AVATAR-*.md first; only ask for genuine gaps.

### heygen-avatar/SKILL.md
Added `## Start Here (Critical)` callout at the top of the skill body:
- Don't batch-ask
- For agent avatars: read SOUL.md / IDENTITY.md first
- Photo is a nudge, not a gate

Restructured Workflow to clarify flow:
- **Phase 0**: Detect target (agent/user/named) from phrasing; check AVATAR file
- **Phase 1**: Identity extraction. For agents: **files first**, questions second. For users: conversational, one question at a time.
- **Reference Photo Nudge** (Phase 2 entry): offers skip, checks AVATAR/IDENTITY for existing photo first
- **Phase 2**: Type A (prompt) or Type B (photo) creation

Previously the Reference Photo Nudge sat between Phase 0 and Phase 1 which encouraged agents to ask for a photo before even knowing who they were building for.

### heygen-video/SKILL.md
Discovery section now explicitly calls out "DO NOT batch-ask all 10 items at once." Most requests carry context ("30-second founder intro" → duration + purpose + tone already known); only ask what's genuinely missing.

## Line counts

- `SKILL.md`: 264 → 266
- `heygen-avatar/SKILL.md`: 296 → 314 (under the relaxed 350-line guideline)
- `heygen-video/SKILL.md`: 556 → 558

## Test plan

Re-run Adam with: "use heygen-avatar and heygen-video to create an avatar of you and make a 30-second intro."

Expected:
1. Announces `heygen-avatar` skill
2. Reads IDENTITY.md + SOUL.md silently
3. Uses extracted traits; asks at most one clarifying question
4. Nudges for photo (one sentence, with skip option)
5. Creates avatar, saves AVATAR file
6. Hands off to `heygen-video` with avatar ready
7. Starts heygen-video Discovery — asks purpose first, not a 7-item form