### PR TITLE
docs: clarify API key is CLI-only, not a hard requirement

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Install HeyGen Skills
 
-Get your API key from [app.heygen.com/settings](https://app.heygen.com/settings/api?nav=API).
+Sign in via MCP (OAuth, no key needed) — or grab an [API key](https://app.heygen.com/settings/api?nav=API) if you'll use the CLI fallback.
 
 ## Option 1 — ClawHub (recommended)
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ After setup, try these prompts with your agent:
 
 ## Requirements
 
-- A HeyGen API key ([get one here](https://app.heygen.com/settings/api?nav=API))
+- A HeyGen account — sign in via MCP (OAuth) or with an [API key](https://app.heygen.com/settings/api?nav=API) if you use the CLI fallback
 - An AI agent that supports skills (Claude Code, OpenClaw, Codex, Cursor, or similar)
 - No runtime dependencies. No packages. No build step.
 


### PR DESCRIPTION
## Summary

Ken flagged that the README implied an API key was a hard requirement — but post-MCP, that's only true for the CLI fallback. MCP uses OAuth with no key needed.

**Changes:**
- `README.md` Requirements: *"A HeyGen API key"* → *"A HeyGen account — sign in via MCP (OAuth) or with an API key if you use the CLI fallback"*
- `INSTALL.md` intro: drop the unconditional *"Get your API key"* line; replace with one-liner that presents MCP first and API key as the CLI fallback

## Test plan

- [ ] MCP user can skim Requirements and not feel they need to go grab an API key
- [ ] CLI user still sees the key link is one click away
- [ ] `grep -n "API key" README.md INSTALL.md` returns only context-appropriate mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)