### PR TITLE
fix(heygen-avatar): Before You Start block ran user-centric logic before Phase 0

### DIFF
--- a/heygen-avatar/SKILL.md
+++ b/heygen-avatar/SKILL.md
@@ -36,27 +36,16 @@ Create and manage HeyGen avatars for anyone: the agent, the user, or named chara
 
 **Prompt-based is the default creation path.** Photo is opt-in, only relevant when the user explicitly wants a real-person digital twin of themselves. Agents and named characters almost always use prompt-based creation.
 
-## Before You Start (Claude Code only)
+## Before You Start (environment detection)
 
 Try to read `SOUL.md` from the workspace root.
 
-- **Found** → OpenClaw environment. Skip this section entirely and go straight to Phase 0.
-- **Not found** → Claude Code environment. Say this before anything else:
-
-First, fetch the user's existing HeyGen avatars.
-
-**MCP:** `list_avatar_groups(ownership=private)` — returns the user's private avatar groups.
-**CLI:** `heygen avatar list --ownership private`
-
-Parse the `data` array.
+- **Found** → OpenClaw environment. Skip this entire section and go straight to Phase 0. Workspace-native identity (SOUL.md, IDENTITY.md) will drive agent onboarding.
+- **Not found** → Claude Code environment, no workspace identity files. Still go to Phase 0 next — do NOT skip ahead to listing user avatars or asking the user for a photo.
 
 **⚠️ AVATAR file caveat:** Ignore any AVATAR-*.md files found in the workspace that belong to a *different* person or agent (e.g., AVATAR-Eve.md when creating an avatar for Claude). Only use an AVATAR file if its name matches the subject you're creating for right now.
 
-If the user **has existing avatars** (non-empty `data` array), present them as numbered options and ask which to use or whether to create a new one. Communicate in `user_language`.
-
-If the user has **no existing avatars** (empty `data`), tell them none were found and offer to create one with a few quick questions. Mention the OpenClaw `SOUL.md` shortcut for future reference. Communicate in `user_language`.
-
-Wait for their answer before proceeding.
+**⚠️ Do NOT fetch HeyGen avatars yet.** That's a Phase 0 sub-step (only after target detection). Fetching before Phase 0 causes the agent to frame the conversation around "your existing avatars" when the default should be creating one for the agent itself.
 
 ## API Mode Detection
 
@@ -148,6 +137,13 @@ Then check `AVATAR-<NAME>.md` at the workspace root:
 - **AVATAR file exists + HeyGen section filled in** → "You already have an avatar set up. Want to add a new look, update it, or start fresh?" Wait for answer.
 - **AVATAR file exists but HeyGen section empty** → skip to Phase 2.
 - **No AVATAR file** → proceed to Phase 1.
+
+**Optional existing-avatar check** (only useful on the user path when the user might already have avatars in their HeyGen account). If Phase 0 target = **user** AND no `AVATAR-<USER>.md` exists, list their HeyGen avatars first:
+
+**MCP:** `list_avatar_groups(ownership=private)`
+**CLI:** `heygen avatar list --ownership private`
+
+If the list is non-empty, present the options and ask which to use or whether to create new. If empty, proceed to Phase 1. Skip this check entirely for agent and named-character targets — those live in AVATAR-*.md, not the HeyGen catalog.
 
 ### Phase 1 — Identity Extraction
 


### PR DESCRIPTION
## Problem

Follow-up to #55. After those fixes were merged, agents still asked the user for a headshot on install-flow prompts:

```
Skills installed, MCP connected, gateway restarted. ✓
Now — before I build your avatar and video, let me walk through this one step at a time.
First up: your avatar.
Do you have a headshot or reference photo I can use?
```

Root cause: the `Before You Start (Claude Code only)` block at the top of `heygen-avatar/SKILL.md` ran BEFORE Phase 0 and was framed entirely around user onboarding.

## The buggy block (before this PR)

```
First, fetch the user's existing HeyGen avatars.
...
If the user has no existing avatars, tell them none were found and
offer to create one with a few quick questions.
```

Two problems:
1. It fired before Phase 0's agent-first default could kick in
2. "Offer to create with a few quick questions" is the batch-ask behavior #51 tried to eliminate

By the time Phase 0 evaluated, the agent was already in "ask for a photo" mode.

## Fix

### Before You Start (renamed 'environment detection')

Now just detects OpenClaw vs Claude Code environment. Both paths proceed to Phase 0 next — no avatar fetching, no user-onboarding questions.

Added explicit callout: **"Do NOT fetch HeyGen avatars yet. That's a Phase 0 sub-step."**

### Phase 0

Moved the existing-avatar listing logic here as an **optional** check:
- Only runs when Phase 0 target = **user** AND no `AVATAR-<USER>.md` exists
- Agent and named-character paths skip this entirely (their identity lives in `AVATAR-*.md`, not the HeyGen catalog)

## Line count

`heygen-avatar/SKILL.md`: 328 → 324 (under 350 cap)

## Test plan

OpenClaw workspace with `SOUL.md`:
1. Before You Start detects `SOUL.md` → skips to Phase 0
2. Phase 0 matches ambiguous/agent phrasing → target = agent
3. Phase 0 checks `AVATAR-<NAME>.md` → does NOT exist → proceed to Phase 1
4. No HeyGen avatar list call (agent path skips it)
5. Phase 1 reads `IDENTITY.md` + `SOUL.md` silently
6. Goes straight to Type A (prompt) creation in Phase 2
7. **No photo ask, no user interrogation**

Claude Code workspace (no `SOUL.md`):
1. Before You Start notes no `SOUL.md` → still goes to Phase 0
2. Phase 0 matches agent phrasing → target = agent
3. No AVATAR file → Phase 1 asks the user for agent's appearance (since no `SOUL.md`)
4. Goes to Phase 2 Type A creation
