### PR TITLE
docs(README): install + hero demo now default to agent avatar, not user

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ AI agent skills for creating avatar videos. Your agent gets a face, a voice, and
 Works with Claude Code, OpenClaw, Codex, Cursor, and other AI coding agents.
 
 ```
-"Create an avatar of me and make a 30-second intro video. Use heygen-avatar and heygen-video — ask me anything before you start."
-→ asks the right questions → builds your avatar → picks the best style → generates the video → delivers the share link
+"Bring yourself to life — create your own avatar and make a 30-second intro video of yourself. Use heygen-avatar and heygen-video, ask me anything before you start."
+→ reads your agent's identity files → asks only what's missing → builds the agent's avatar → picks the best style → generates the video → delivers the share link
 ```
 
 ## Install
@@ -14,7 +14,7 @@ Works with Claude Code, OpenClaw, Codex, Cursor, and other AI coding agents.
 Paste this into your agent to get started:
 
 ```
-Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory. If MCP is connected, you're done. Otherwise install the HeyGen CLI from https://static.heygen.ai/cli/install.sh and run `heygen auth login`. Then use heygen-avatar and heygen-video to create an avatar of me and make a short cinematic intro video. Ask me what you need before starting.
+Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory. If MCP is connected, you're done. Otherwise install the HeyGen CLI from https://static.heygen.ai/cli/install.sh and run `heygen auth login`. Then use heygen-avatar and heygen-video to bring yourself to life — create your own avatar and make a short cinematic intro video of yourself introducing who you are. Ask me what you need before starting.
 ```
 
 Or follow the steps below manually.


### PR DESCRIPTION
## Problem

The default copy-paste install instruction said "create an avatar of **me** and make a short cinematic intro video" — which routes to the user path in Phase 0 (possessive pronoun "me"). Users pasting this verbatim ended up with their own HeyGen avatar, not the agent's.

This contradicts:
- The README hero tagline: "Your agent gets a face, a voice, and the ability to send video like a message."
- The agent-first GTM thesis (#51, #55, #56)

Testing with the original instruction: the agent correctly routes to "user" (matching the possessive pronoun), asks for a photo, and sets up a HeyGen avatar for the user — not the agent. Skill logic was doing its job; the install prompt itself was wrong.

## Fix

### Install snippet (line 17)
Before:
```
...Then use heygen-avatar and heygen-video to create an avatar of me and
make a short cinematic intro video. Ask me what you need before starting.
```

After:
```
...Then use heygen-avatar and heygen-video to bring yourself to life —
create your own avatar and make a short cinematic intro video of yourself
introducing who you are. Ask me what you need before starting.
```

### Hero demo quote (line 8)
Before:
```
"Create an avatar of me and make a 30-second intro video..."
→ asks the right questions → builds your avatar...
```

After:
```
"Bring yourself to life — create your own avatar and make a 30-second
intro video of yourself..."
→ reads your agent's identity files → asks only what's missing
→ builds the agent's avatar...
```

## No SKILL.md changes

Phase 0 already handles this phrasing correctly — "bring yourself to life" and "create your own avatar" both match the agent triggers in the description. The fix is purely in the demo copy.

## Test

When the request contains explicit agent language ("bring yourself to life", "set up your avatar"), Phase 0 routes to agent, reads `SOUL.md`/`IDENTITY.md`, asks only for missing appearance traits, no photo nudge, no batch-ask.

Related:
- #51 (Phase 0 routing fix)
- #55 (agent-first default)
- #56 (Before You Start block fix)
