### PR TITLE
fix(SKILL): HEYGEN_API_KEY presence → use CLI, short-circuit MCP

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -59,11 +59,12 @@ You are a video producer. Not a form. Not a CLI wrapper. A producer who understa
 
 **Pick one transport at session start. Never mix, never switch mid-session, never narrate the choice.**
 
-Detect which is available:
+Detect in this order:
 
-1. **MCP mode** — HeyGen MCP tools are visible in the toolset (tools matching `mcp__heygen__*`). OAuth auth, uses existing plan credits.
-2. **CLI mode** — MCP tools NOT available AND `heygen --version` exits 0. Auth via `HEYGEN_API_KEY` env or `heygen auth login`.
-3. **Neither** — tell the user once: "To use this skill, connect the HeyGen MCP server or install the HeyGen CLI: `curl -fsSL https://static.heygen.ai/cli/install.sh | bash` then `heygen auth login`."
+1. **CLI mode (API-key override)** — If `HEYGEN_API_KEY` is set in the environment AND `heygen --version` exits 0, use CLI. API-key presence is an explicit user signal that they want direct API access; it short-circuits MCP detection. No question asked.
+2. **MCP mode** — No `HEYGEN_API_KEY` set AND HeyGen MCP tools are visible in the toolset (tools matching `mcp__heygen__*`). OAuth auth, uses existing plan credits.
+3. **CLI mode (fallback)** — MCP tools NOT available AND `heygen --version` exits 0. Auth via `heygen auth login` (persists to `~/.heygen/credentials`).
+4. **Neither** — tell the user once: "To use this skill, connect the HeyGen MCP server or install the HeyGen CLI: `curl -fsSL https://static.heygen.ai/cli/install.sh | bash` then `heygen auth login`."
 
 **Hard rules:**
 - **Never call `curl api.heygen.com/...`** — both modes route through their own surface.


### PR DESCRIPTION
## Problem

Current detection order: MCP preferred → CLI fallback. If both are configured (MCP connected AND `HEYGEN_API_KEY` set), MCP wins silently. That's wrong: an explicit API key is an explicit user signal — they want direct API access, not OAuth.

Net effect: users who followed the CLI install path (API key in env) get silently routed through MCP if an MCP server happens to be present. Surprising, and it defeats the whole point of setting a key.

## Fix

New 4-level priority:

1. **CLI mode (API-key override)** — `HEYGEN_API_KEY` set AND `heygen --version` exits 0 → use CLI. Short-circuits MCP detection.
2. **MCP mode** — no key AND `mcp__heygen__*` tools visible → use MCP (OAuth, plan credits).
3. **CLI mode (fallback)** — no key AND no MCP AND `heygen --version` exits 0 → use CLI with `heygen auth login`.
4. **Neither** — tell the user how to connect.

## Scope

- Single edit to root `SKILL.md` (+5 -4 lines)
- Prompt-only, no API/behavioral changes

Related: #59
