### PR TITLE
docs(README): API key first, MCP as alternative

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Install HeyGen Skills
 
-Sign in via MCP (OAuth, no key needed) — or grab an [API key](https://app.heygen.com/settings/api?nav=API) if you'll use the CLI fallback.
+Grab an [API key](https://app.heygen.com/api) and set it in your shell. If you're already on a HeyGen plan with MCP connected to your agent, you can skip the key — MCP will be used automatically.
 
 ## Option 1 — ClawHub (recommended)
 
@@ -28,22 +28,28 @@ git clone https://github.com/heygen-com/skills.git ~/.claude/skills/heygen-skill
 
 ## Auth
 
-Two options — the skills prefer MCP when it's available:
+Two auth modes with explicit priority:
 
-**MCP (recommended, no API key needed):** connect HeyGen's remote MCP server to your agent — OAuth handles auth. See README for agent-specific setup.
+| Priority | Mode | Trigger | Billing |
+|----------|------|---------|---------|
+| 1 | **CLI (API key)** | `HEYGEN_API_KEY` is set | Direct API usage (separately billed) |
+| 2 | **MCP (OAuth)** | MCP tools visible AND no API key | HeyGen plan credits (existing subscription) |
+| 3 | **CLI (fallback)** | `heygen auth login` session | Direct API usage |
 
-**HeyGen CLI (fallback):** install the CLI and authenticate:
+**CLI with API key (recommended for agents):**
 ```bash
 curl -fsSL https://static.heygen.ai/cli/install.sh | bash
-heygen --version        # verify binary is on PATH
-heygen auth login       # persists to ~/.heygen/credentials
-# OR
 export HEYGEN_API_KEY=<your-key>
+heygen --version        # verify binary is on PATH
 heygen auth status      # verify auth
 ```
+
+> If `HEYGEN_API_KEY` is set, the skills use the CLI. This is the most predictable setup for agent workflows.
+
+**MCP (zero-setup if on a HeyGen plan):** connect HeyGen's remote MCP server to your agent — OAuth handles auth, calls use your existing plan credits. See README for agent-specific setup.
 
 ## First Run
 
 Paste this prompt to your agent — it will find the right paths automatically:
 
-> Install the HeyGen Skills from https://github.com/heygen-com/skills.git — clone it into your skills directory (find it with your config or ask if unsure). If MCP isn't connected, install the HeyGen CLI via `curl -fsSL https://static.heygen.ai/cli/install.sh | bash` and run `heygen auth login`. Then use the heygen-avatar skill to create an avatar for me, and heygen-video to make a 30-60 second intro video, casual tone.
+> Install the HeyGen Skills from https://github.com/heygen-com/skills.git — clone it into your skills directory (find it with your config or ask if unsure). Install the HeyGen CLI via `curl -fsSL https://static.heygen.ai/cli/install.sh | bash` and export HEYGEN_API_KEY=\<your-key\> (get one at https://app.heygen.com/api). Or, if you're on a HeyGen plan and already have MCP connected to your agent, skip the key step — MCP will be used automatically. Then use the heygen-avatar skill to create an avatar for me, and heygen-video to make a 30-60 second intro video, casual tone.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Works with Claude Code, OpenClaw, Codex, Cursor, and other AI coding agents.
 Paste this into your agent to get started:
 
 ```
-Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory. Install the HeyGen CLI from https://static.heygen.ai/cli/install.sh and export HEYGEN_API_KEY=<your-key> (get one at https://app.heygen.com/settings/api?nav=API). Then use heygen-avatar and heygen-video to bring yourself to life — create your own avatar and make a short cinematic intro video of yourself introducing who you are. Ask me what you need before starting.
+Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory. Install the HeyGen CLI from https://static.heygen.ai/cli/install.sh and export HEYGEN_API_KEY=<your-key> (get one at https://app.heygen.com/api). Then use heygen-avatar and heygen-video to bring yourself to life — create your own avatar and make a short cinematic intro video of yourself introducing who you are. Ask me what you need before starting.
 ```
 
 Or follow the steps below manually.
@@ -36,7 +36,7 @@ git clone --single-branch --depth 1 https://github.com/heygen-com/skills.git <in
 
 ### Step 2 — Get your HeyGen API key
 
-1. Go to **[app.heygen.com/settings/api](https://app.heygen.com/settings/api?nav=API)** (Settings → API)
+1. Go to **[app.heygen.com/api](https://app.heygen.com/api)** (Settings → API)
 2. Generate a new API key
 3. Save it somewhere safe — you can't view it again after the modal closes
 
@@ -143,7 +143,7 @@ The skills support two auth modes with explicit priority:
 
 ### CLI with API key (recommended for agents)
 
-Get a key at **[app.heygen.com/settings/api](https://app.heygen.com/settings/api?nav=API)**, then:
+Get a key at **[app.heygen.com/api](https://app.heygen.com/api)**, then:
 
 ```bash
 export HEYGEN_API_KEY=your-key-here
@@ -183,7 +183,7 @@ After setup, try these prompts with your agent:
 
 ## Requirements
 
-- A HeyGen account — sign in via MCP (OAuth) or with an [API key](https://app.heygen.com/settings/api?nav=API) if you use the CLI fallback
+- A HeyGen account — sign in via MCP (OAuth) or with an [API key](https://app.heygen.com/api) if you use the CLI fallback
 - An AI agent that supports skills (Claude Code, OpenClaw, Codex, Cursor, or similar)
 - No runtime dependencies. No packages. No build step.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Works with Claude Code, OpenClaw, Codex, Cursor, and other AI coding agents.
 Paste this into your agent to get started:
 
 ```
-Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory. If MCP is connected, you're done. Otherwise install the HeyGen CLI from https://static.heygen.ai/cli/install.sh and run `heygen auth login`. Then use heygen-avatar and heygen-video to bring yourself to life — create your own avatar and make a short cinematic intro video of yourself introducing who you are. Ask me what you need before starting.
+Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory. Install the HeyGen CLI from https://static.heygen.ai/cli/install.sh and export HEYGEN_API_KEY=<your-key> (get one at https://app.heygen.com/settings/api?nav=API). Then use heygen-avatar and heygen-video to bring yourself to life — create your own avatar and make a short cinematic intro video of yourself introducing who you are. Ask me what you need before starting.
 ```
 
 Or follow the steps below manually.
@@ -34,13 +34,40 @@ Detect which agent you are and clone to the right path:
 git clone --single-branch --depth 1 https://github.com/heygen-com/skills.git <install-path>/heygen-skills
 ```
 
-### Step 2 — Connect to HeyGen (pick one)
+### Step 2 — Get your HeyGen API key
 
-The skills auto-detect which mode is available and prefer MCP when connected.
+1. Go to **[app.heygen.com/settings/api](https://app.heygen.com/settings/api?nav=API)** (Settings → API)
+2. Generate a new API key
+3. Save it somewhere safe — you can't view it again after the modal closes
 
-**Option A — MCP (recommended, no API key needed)**
+### Step 3 — Install the HeyGen CLI
 
-Connect HeyGen's remote MCP server to your agent. OAuth handles auth and the skills use your existing HeyGen plan credits — no separate API billing.
+One-line install (macOS / Linux):
+
+```bash
+curl -fsSL https://static.heygen.ai/cli/install.sh | bash
+```
+
+Then set your API key:
+
+```bash
+export HEYGEN_API_KEY=<your-key>           # ephemeral (current shell)
+# or persist it:
+echo 'export HEYGEN_API_KEY=<your-key>' >> ~/.zshrc   # or ~/.bashrc
+```
+
+Verify:
+
+```bash
+heygen --version
+heygen auth status
+```
+
+The [HeyGen CLI](https://github.com/heygen-com/heygen-cli) is a single static binary. No runtime deps.
+
+### Alternative: MCP (OAuth, no API key)
+
+If you prefer OAuth and already have a HeyGen plan with credits, connect the remote MCP server instead of setting an API key. The skills will auto-detect MCP when no `HEYGEN_API_KEY` is set.
 
 Claude Code:
 ```bash
@@ -60,21 +87,9 @@ OpenClaw: add to `~/.openclaw/openclaw.json`:
 
 The first call triggers an OAuth consent flow in your browser.
 
-**Option B — HeyGen CLI fallback**
+> **Priority:** If `HEYGEN_API_KEY` is set, the skills use the CLI. Otherwise they look for MCP tools. Set the key only if you want direct API access; otherwise use MCP.
 
-If MCP is unavailable or you prefer direct access:
-
-```bash
-curl -fsSL https://static.heygen.ai/cli/install.sh | bash
-heygen auth login   # or: export HEYGEN_API_KEY=<your-key>
-heygen auth status  # verify
-```
-
-The [HeyGen CLI](https://github.com/heygen-com/heygen-cli) is a single static binary. Auth persists to `~/.heygen/credentials`. Get an API key at [app.heygen.com/settings/api](https://app.heygen.com/settings/api?nav=API).
-
-> **Either path works.** The skills detect MCP tools matching `mcp__heygen__*` and use them first. If none are found, they fall back to `heygen <noun> <verb>` CLI calls. You can have both configured — MCP wins.
-
-### Step 3 — Create your avatar
+### Step 4 — Create your avatar
 
 Ask the user for a photo (URL or file), then use the **heygen-avatar** skill:
 
@@ -82,7 +97,7 @@ Ask the user for a photo (URL or file), then use the **heygen-avatar** skill:
 
 The skill uploads the photo, creates a persistent digital twin with a voice, and saves an `AVATAR-<NAME>.md` file for future use.
 
-### Step 4 — Make your first video
+### Step 5 — Make your first video
 
 Use the **heygen-video** skill to generate an intro video with the avatar you just created:
 
@@ -118,25 +133,38 @@ Skills communicate through `AVATAR-<NAME>.md` files. heygen-avatar writes them, 
 
 ## Authentication
 
-The skills support two auth modes and auto-detect which is available.
+The skills support two auth modes with explicit priority:
 
-### MCP (preferred)
+| Priority | Mode | Trigger | Best for |
+|----------|------|---------|----------|
+| 1 | **CLI (API key)** | `HEYGEN_API_KEY` is set | Agents, CI, scripts, direct API access |
+| 2 | **MCP (OAuth)** | MCP tools visible AND no API key | Users on a HeyGen plan, zero-setup |
+| 3 | **CLI (fallback)** | `heygen auth login` session | Interactive CLI users |
 
-When HeyGen's remote MCP server is connected to your agent, the skills use it automatically. No API key needed, OAuth handles everything, and calls use your existing HeyGen plan credits.
+### CLI with API key (recommended for agents)
+
+Get a key at **[app.heygen.com/settings/api](https://app.heygen.com/settings/api?nav=API)**, then:
+
+```bash
+export HEYGEN_API_KEY=your-key-here
+```
+
+If `HEYGEN_API_KEY` is set, the skills use the CLI directly. No MCP probing. This is the most predictable setup for agent workflows.
+
+The [HeyGen CLI](https://github.com/heygen-com/heygen-cli) pattern is `heygen <noun> <verb>`. Output is JSON on stdout with stable exit codes.
+
+- **Verify**: `heygen auth status`
+- **Alternative login**: `heygen auth login` — interactive browser flow, persists to `~/.heygen/credentials`
+
+### MCP (OAuth, no API key)
+
+If you don't set an API key and HeyGen's remote MCP server is connected to your agent, the skills use MCP via OAuth. Calls run against your existing HeyGen plan credits.
 
 - Endpoint: `https://mcp.heygen.com/mcp/v1/`
 - Tool namespace: `mcp__heygen__*`
 - [MCP docs](https://developers.heygen.com/docs/mcp-remote)
 
-### HeyGen CLI (fallback)
-
-If MCP isn't available, the skills fall back to the [HeyGen CLI](https://github.com/heygen-com/heygen-cli) (`heygen` binary). Pattern: `heygen <noun> <verb>`. Output is JSON on stdout with stable exit codes.
-
-- **Interactive login**: `heygen auth login` — persists to `~/.heygen/credentials`
-- **Environment variable**: `export HEYGEN_API_KEY="your-key"` — agent-/CI-friendly; takes precedence over the credentials file
-- **Verify anytime**: `heygen auth status`
-
-You can have both configured — the skills check for MCP first and only fall back to the CLI if MCP tools aren't visible.
+You can have both configured — if `HEYGEN_API_KEY` is set, CLI wins.
 
 ## Things to Try
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Works with Claude Code, OpenClaw, Codex, Cursor, and other AI coding agents.
 Paste this into your agent to get started:
 
 ```
-Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory. Install the HeyGen CLI from https://static.heygen.ai/cli/install.sh and export HEYGEN_API_KEY=<your-key> (get one at https://app.heygen.com/api). Then use heygen-avatar and heygen-video to bring yourself to life — create your own avatar and make a short cinematic intro video of yourself introducing who you are. Ask me what you need before starting.
+Install HeyGen Skills from https://github.com/heygen-com/skills — clone the repo into your skills directory. Install the HeyGen CLI from https://static.heygen.ai/cli/install.sh and export HEYGEN_API_KEY=<your-key> (get one at https://app.heygen.com/api). Or, if you're on a HeyGen plan and already have MCP connected to your agent, skip the key step — MCP will be used automatically. Then use heygen-avatar and heygen-video to bring yourself to life — create your own avatar and make a short cinematic intro video of yourself introducing who you are. Ask me what you need before starting.
 ```
 
 Or follow the steps below manually.
@@ -51,10 +51,10 @@ curl -fsSL https://static.heygen.ai/cli/install.sh | bash
 Then set your API key:
 
 ```bash
-export HEYGEN_API_KEY=<your-key>           # ephemeral (current shell)
-# or persist it:
-echo 'export HEYGEN_API_KEY=<your-key>' >> ~/.zshrc   # or ~/.bashrc
+export HEYGEN_API_KEY=<your-key>
 ```
+
+That's ephemeral (current shell only). To persist across sessions, add `export HEYGEN_API_KEY=<your-key>` to your shell profile (`~/.zshrc`, `~/.bashrc`, or equivalent).
 
 Verify:
 
@@ -135,11 +135,13 @@ Skills communicate through `AVATAR-<NAME>.md` files. heygen-avatar writes them, 
 
 The skills support two auth modes with explicit priority:
 
-| Priority | Mode | Trigger | Best for |
-|----------|------|---------|----------|
-| 1 | **CLI (API key)** | `HEYGEN_API_KEY` is set | Agents, CI, scripts, direct API access |
-| 2 | **MCP (OAuth)** | MCP tools visible AND no API key | Users on a HeyGen plan, zero-setup |
-| 3 | **CLI (fallback)** | `heygen auth login` session | Interactive CLI users |
+| Priority | Mode | Trigger | Billing | Best for |
+|----------|------|---------|---------|----------|
+| 1 | **CLI (API key)** | `HEYGEN_API_KEY` is set | Direct API usage ($, separately billed) | Agents, CI, scripts |
+| 2 | **MCP (OAuth)** | MCP tools visible AND no API key | HeyGen plan credits (no extra billing) | Users on a HeyGen plan |
+| 3 | **CLI (fallback)** | `heygen auth login` session | Direct API usage ($) | Interactive CLI users |
+
+**Billing tradeoff:** CLI mode bills against your HeyGen API usage (separately metered). MCP mode consumes your existing HeyGen plan credits — no extra API billing. Pick the mode that matches how you want to be charged.
 
 ### CLI with API key (recommended for agents)
 


### PR DESCRIPTION
## Problem

README install flow leads with MCP (OAuth) as "recommended, no API key needed" and relegates the HeyGen CLI to a fallback subsection. This conflicts with the upcoming skill priority (#60): if `HEYGEN_API_KEY` is set, the skills use the CLI, not MCP. Users following the README get steered toward MCP, then surprised when setting an API key silently changes transport.

Also: new users had to hunt for the API key generation URL — it was buried in the CLI subsection, not called out as a setup step.

## Fix

### Install section restructured (Step 2 and Step 3 added)

- **Step 2 — Get your HeyGen API key** — links directly to `app.heygen.com/settings/api`, explicit about "you can't view it again"
- **Step 3 — Install the HeyGen CLI** — one-line `curl` install + `HEYGEN_API_KEY` env-var persistence (current shell + `~/.zshrc` / `~/.bashrc`)
- **Alternative: MCP (OAuth, no API key)** — moved below with clear when-to-use framing
- Original Step 3 (Create your avatar) renumbered → Step 4
- Original Step 4 (Make your first video) renumbered → Step 5

### Paste prompt updated

The copy-paste install prompt at the top now mentions installing the CLI + exporting `HEYGEN_API_KEY` with the key-generation URL inline.

### Authentication section rewritten

Priority table replaces the "MCP preferred, CLI fallback" framing:

| Priority | Mode | Trigger | Best for |
|----------|------|---------|----------|
| 1 | CLI (API key) | `HEYGEN_API_KEY` is set | Agents, CI, scripts |
| 2 | MCP (OAuth) | MCP visible AND no API key | Users on HeyGen plan, zero-setup |
| 3 | CLI (fallback) | `heygen auth login` session | Interactive CLI users |

Explicit: *"If `HEYGEN_API_KEY` is set, CLI wins."*

## Scope

- `README.md` only (+60 -32 lines)
- Docs-only change
- Complements #60 (skill-side priority change)

Related: #60