### PR TITLE
feat: bundle official HeyGen MCP server in all three plugin runtimes

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -23,6 +23,7 @@
     "avatar-video"
   ],
   "skills": "./",
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "HeyGen",
     "shortDescription": "Avatar videos and personalized video messages",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "heygen": {
+      "type": "http",
+      "url": "https://mcp.heygen.com/mcp/v1/",
+      "note": "Official HeyGen MCP server. OAuth on first connection — runs against the user's existing HeyGen plan credits. The heygen-avatar and heygen-video skills detect this MCP and use it instead of the HeyGen CLI when available."
+    }
+  }
+}

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "heygen": {
+      "type": "http",
+      "url": "https://mcp.heygen.com/mcp/v1/",
+      "note": "Official HeyGen MCP server. OAuth on first connection — runs against the user's existing HeyGen plan credits. The heygen-avatar and heygen-video skills detect this MCP and use it instead of the HeyGen CLI when available."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The `heygen-avatar` and `heygen-video` skills already detect `mcp__heygen__*` and prefer it over the CLI, but until now the plugin manifests didn't ship the MCP server itself — users had to wire HeyGen MCP separately, defeating the zero-config promise of installing a plugin.

This bundles the official remote HeyGen MCP (`https://mcp.heygen.com/mcp/v1/`) into all three plugin runtimes.

## Changes

- **`.mcp.json`** (new, at repo root) — read by Claude Code (auto-discovery) and Codex (via manifest pointer).
- **`mcp.json`** (new, at repo root) — read by Cursor (auto-discovery, unprefixed filename per Cursor docs). Same content as `.mcp.json`.
- **`.codex-plugin/plugin.json`** — adds `"mcpServers": "./.mcp.json"` pointer, matching the `cloudflare` and `build-ios-apps` reference plugins in `openai/plugins`.

No skill content changes. No version bump in this PR — release-please will pick up the `feat:` commit and propose `1.4.0` on the next release PR.

## Result

Installing this plugin in any of the three runtimes auto-wires HeyGen MCP. OAuth happens on first connection and runs against the user's existing HeyGen plan credits — no API key, no CLI install required.

The HeyGen CLI remains as a documented fallback for users who'd rather use a long-lived API key (CI / headless agents).

## Companion PR

[`openai/plugins#192`](https://github.com/openai/plugins/pull/192) ships the same MCP wiring downstream in the OpenAI Codex marketplace plugin.

## Test plan

- [x] All four manifests parse as JSON (`.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.mcp.json`, `mcp.json`)
- [x] Codex manifest shape matches the documented schema at <https://developers.openai.com/codex/plugins/build>
- [x] `.mcp.json` shape matches the reference Codex plugins (`cloudflare`, `build-ios-apps`)
- [ ] Install via Claude Code plugin marketplace and verify `/mcp` shows `heygen` server connected
- [ ] Install via Codex plugin marketplace and verify HeyGen MCP is wired without a separate setup step
- [ ] Install via Cursor and verify the HeyGen MCP server appears in the MCP list

🤖 Generated with [Claude Code](https://claude.com/claude-code)