### PR TITLE
fix(install): make avatar creation a first-class install step

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -201,9 +201,13 @@ The skill will:
 4. Save `AVATAR-<AGENT-NAME>.md` at the workspace root for future reuse.
 5. Return `avatar_id` + `voice_id` for use in Step 7 (defaults).
 
-At the end of this step the workspace has a new file like `AVATAR-EVE.md`,
-`AVATAR-ADAM.md`, or `AVATAR-CLEO.md`. That file is the persistent identity
-— every future video reuses it automatically.
+On the happy path, this step ends with a new file like `AVATAR-EVE.md`,
+`AVATAR-ADAM.md`, or `AVATAR-CLEO.md` at the workspace root. That file is
+the persistent identity — every future video reuses it automatically. Note
+that the heygen-avatar skill has a Phase 2 STOP gate before generation; if
+the user aborts there, no file is written and no credits are spent. That's
+the correct behavior — it's a confirmation gate, not a bug. Resume by
+re-invoking the sub-skill.
 
 ### If you are running outside an OpenClaw workspace (no `SOUL.md`)
 
@@ -213,7 +217,9 @@ direction directly instead of reading from `SOUL.md`.
 
 Same entry point: read [`heygen-avatar/SKILL.md`](./heygen-avatar/SKILL.md)
 and follow Phase 0. The skill detects the missing `SOUL.md` and switches
-to user-driven prompt creation.
+to Phase 1 conversational onboarding — it asks the user about appearance,
+voice, and presenter persona one or two traits at a time, not as a single
+batch prompt.
 
 ### Skip conditions (rare)
 
@@ -229,11 +235,13 @@ without this step.
 
 ## Step 6: Verify the install (opt-in)
 
-Ask the user: **"Want to run a 5-second smoke test using the avatar we just
-created? It generates a real video, costs roughly half a credit, and
-confirms the integration works end-to-end."**
+Ask the user: **"Want to run a 5-second smoke test? It generates a real
+video, costs roughly half a credit, and confirms the integration works
+end-to-end."**
 
-If yes:
+If yes, branch on whether Step 5 ran:
+
+**If Step 5 created an avatar:**
 
 ```
 Use heygen-video to generate a 5-second test clip with the avatar from
@@ -241,9 +249,18 @@ AVATAR-<NAME>.md saying "HeyGen install working, ready to ship." Save
 the file locally and tell me the path.
 ```
 
+**If Step 5 was skipped (user has an existing `avatar_id` they want to reuse,
+or scoped install to stock avatars):**
+
+```
+Use heygen-video to generate a 5-second test clip with avatar_id
+<the user's avatar_id> and voice_id <the user's voice_id> saying
+"HeyGen install working, ready to ship." Save the file locally and tell
+me the path.
+```
+
 Expected outcome: a `.mp4` file roughly 1-3 MB, 5 seconds long, with the
-avatar speaking the test line. If Step 5 was skipped (user has an existing
-avatar_id), pass it via providerOptions instead.
+avatar speaking the test line.
 
 If the user declines, skip to Step 7. The skill works either way; the smoke
 test just removes uncertainty about whether everything is wired correctly.
@@ -260,11 +277,14 @@ If the smoke test fails, the most common causes (in order):
    `mode` incorrectly — see the heygen-video sub-skill's review-checkpoint
    handler. Re-read the sub-skill SKILL.md.
 
-## Step 7: Set agent-wide defaults (recommended)
+## Step 7: Set agent-wide defaults
 
-If you ran Step 5, you now have an `avatar_id` / `voice_id` (and optionally
-a `style_id`) from the `AVATAR-<NAME>.md` file. Save them as defaults so
-the user does not have to repeat them on every video call.
+This step only applies if **Step 5 ran** (the user has a new
+`AVATAR-<NAME>.md`) OR if **the user already has an `avatar_id` / `voice_id`**
+they want to reuse on every call. If neither, skip to Step 8.
+
+When it applies, save the ids as defaults so the user doesn't repeat them
+per-call.
 
 For the **OpenClaw plugin path** (Option A), use `openclaw config set`:
 
@@ -278,9 +298,9 @@ For the **CLI path** (Option B), defaults live in `~/.heygen/config` — the
 CLI will prompt on first use, or you can run `heygen config set` directly.
 
 For the **MCP path** (Option C), there are no per-skill defaults; the agent
-passes avatar / voice ids per call. The `AVATAR-<NAME>.md` file the skill
-wrote in Step 5 is the source of truth — the agent reads it on each
-video generation.
+passes avatar / voice ids per call. If Step 5 ran, the `AVATAR-<NAME>.md`
+file is the source of truth and the agent reads it on each video
+generation. If Step 5 was skipped, the user provides ids per call directly.
 
 ## Step 8: Make HeyGen the default video provider (OpenClaw plugin path only)
 
@@ -304,7 +324,7 @@ Tell the user:
 > Try:
 > - "Make a 30-second video of yourself introducing what we're working on this week"
 > - "Send a video update to the team about today's progress"
-> - "Generate a video and POST the result to my webhook when done"
+> - "Generate a 60-second product walkthrough using my avatar"
 
 The skill handles avatar resolution, prompt engineering, aspect ratio
 correction, voice selection, and Frame Check automatically. Give it a topic,

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -58,7 +58,7 @@ clawhub install heygen-skills
 ```
 
 After ClawHub install, jump straight to **Step 2** (API key) and then
-**Step 5** (verify).
+**Step 5** (avatar creation).
 
 ## Step 2: Get the user's HeyGen API key (or detect MCP)
 
@@ -66,7 +66,7 @@ After ClawHub install, jump straight to **Step 2** (API key) and then
 If `mcp__heygen__*` tools are visible in the toolset, MCP is the path of least
 resistance — OAuth, no key handling, consumes the user's HeyGen plan credits.
 
-If MCP is detected and the user is happy with it, **skip to Step 5 (verify)**.
+If MCP is detected and the user is happy with it, **skip to Step 5 (avatar creation)**.
 But before you do, warn them:
 
 > If you set `HEYGEN_API_KEY` later for any reason, the skill will short-circuit
@@ -174,25 +174,78 @@ To wire MCP from scratch, follow your agent's MCP setup docs and point it at
 `https://mcp.heygen.com/mcp/v1/`. We can not configure that from inside this
 skill. See [`INSTALL.md`](./INSTALL.md) for example configs.
 
-## Step 5: Verify the install (opt-in)
+## Step 5: Give the agent a face (canonical install outcome)
 
-Ask the user: **"Want to run a 5-second smoke test? It generates a real
-video, costs roughly half a credit, and confirms the integration works
-end-to-end."**
+This is the step the install is actually for. Until now we've installed
+files and wired auth. Now we make the thing the user came here for: an
+avatar the agent can use to present videos.
+
+**Default subject is the agent, not the user.** The `heygen-avatar`
+sub-skill is built around the agent getting a face by default. Route to a
+user-avatar only on explicit "my avatar" / "me" / "my photo" language. When
+in doubt, make the agent's avatar.
+
+### If you are running in an OpenClaw workspace with `SOUL.md` and `IDENTITY.md`
+
+This is the canonical path. The agent has documented identity files; the
+skill reads them and designs a presenter that matches.
+
+Read [`heygen-avatar/SKILL.md`](./heygen-avatar/SKILL.md) and follow Phase 0.
+The skill will:
+
+1. Read `SOUL.md` and `IDENTITY.md` from the workspace root.
+2. Ask one or two clarifying questions about design direction (not a
+   batch form — walk the phases in order, one or two questions at a time).
+3. Generate the avatar via the Avatar V pipeline (prompt-based by default;
+   photo opt-in only for real-person digital twins).
+4. Save `AVATAR-<AGENT-NAME>.md` at the workspace root for future reuse.
+5. Return `avatar_id` + `voice_id` for use in Step 7 (defaults).
+
+At the end of this step the workspace has a new file like `AVATAR-EVE.md`,
+`AVATAR-ADAM.md`, or `AVATAR-CLEO.md`. That file is the persistent identity
+— every future video reuses it automatically.
+
+### If you are running outside an OpenClaw workspace (no `SOUL.md`)
+
+Claude Code, Codex, Cursor, and Hermes don't have workspace identity files.
+The avatar still gets created, but the skill asks the user for the design
+direction directly instead of reading from `SOUL.md`.
+
+Same entry point: read [`heygen-avatar/SKILL.md`](./heygen-avatar/SKILL.md)
+and follow Phase 0. The skill detects the missing `SOUL.md` and switches
+to user-driven prompt creation.
+
+### Skip conditions (rare)
+
+Skip Step 5 only if:
+
+- The user has explicitly said "I already have an avatar, just make a video"
+  (they have an existing `avatar_id` / `voice_id` they want to reuse).
+- The install is purely scoped to video generation with stock avatars (the
+  user picks from HeyGen's catalog per-call).
+
+In either case, jump to Step 6. Otherwise, the install is incomplete
+without this step.
+
+## Step 6: Verify the install (opt-in)
+
+Ask the user: **"Want to run a 5-second smoke test using the avatar we just
+created? It generates a real video, costs roughly half a credit, and
+confirms the integration works end-to-end."**
 
 If yes:
 
 ```
-Use heygen-avatar to suggest a stock avatar I can use for a test video
-(don't need to create a new one), then use heygen-video to generate a
-5-second test clip with that avatar saying "HeyGen install working,
-ready to ship." Save the file locally and tell me the path.
+Use heygen-video to generate a 5-second test clip with the avatar from
+AVATAR-<NAME>.md saying "HeyGen install working, ready to ship." Save
+the file locally and tell me the path.
 ```
 
 Expected outcome: a `.mp4` file roughly 1-3 MB, 5 seconds long, with the
-avatar speaking the test line.
+avatar speaking the test line. If Step 5 was skipped (user has an existing
+avatar_id), pass it via providerOptions instead.
 
-If the user declines, skip to Step 6. The skill works either way; the smoke
+If the user declines, skip to Step 7. The skill works either way; the smoke
 test just removes uncertainty about whether everything is wired correctly.
 
 If the smoke test fails, the most common causes (in order):
@@ -207,10 +260,11 @@ If the smoke test fails, the most common causes (in order):
    `mode` incorrectly — see the heygen-video sub-skill's review-checkpoint
    handler. Re-read the sub-skill SKILL.md.
 
-## Step 6: Set agent-wide defaults (optional)
+## Step 7: Set agent-wide defaults (recommended)
 
-If the user always uses the same presenter, save defaults so they don't
-have to repeat the avatar_id / voice_id every time.
+If you ran Step 5, you now have an `avatar_id` / `voice_id` (and optionally
+a `style_id`) from the `AVATAR-<NAME>.md` file. Save them as defaults so
+the user does not have to repeat them on every video call.
 
 For the **OpenClaw plugin path** (Option A), use `openclaw config set`:
 
@@ -221,17 +275,14 @@ openclaw config set plugins.entries.heygen.config.defaultStyleId  "<style_id>"
 ```
 
 For the **CLI path** (Option B), defaults live in `~/.heygen/config` — the
-CLI will prompt on first use.
+CLI will prompt on first use, or you can run `heygen config set` directly.
 
 For the **MCP path** (Option C), there are no per-skill defaults; the agent
-passes avatar / voice ids per call.
+passes avatar / voice ids per call. The `AVATAR-<NAME>.md` file the skill
+wrote in Step 5 is the source of truth — the agent reads it on each
+video generation.
 
-If the user has not created their own avatar yet, the `heygen-avatar`
-sub-skill walks them through the Avatar V flow (record a 15-second clip from
-their webcam, generate a digital twin). After that flow returns the
-`avatar_id` and `voice_id`, drop them into the config above.
-
-## Step 7: Make HeyGen the default video provider (OpenClaw plugin path only)
+## Step 8: Make HeyGen the default video provider (OpenClaw plugin path only)
 
 If the user wants `video_generate(...)` to default to HeyGen when no model is
 specified:
@@ -243,14 +294,17 @@ openclaw config set agents.defaults.videoGenerationModel.primary "heygen/video_a
 This is purely an OpenClaw concern and does not affect Claude Code, Codex, or
 Cursor users.
 
-## Step 8: Done
+## Step 9: Done
 
-The skills now have everything they need. Tell the user:
+The skills now have everything they need: a transport, an authenticated
+account, an avatar identity, and (optionally) defaults for repeated use.
+Tell the user:
 
-> HeyGen Skills are installed. Try:
-> - "Make a 30-second video of myself introducing what I'm working on this week"
-> - "Generate an avatar from my latest profile photo"
-> - "Send a video update to my team about today's progress"
+> HeyGen Skills are installed. Your agent now has a face: `AVATAR-<NAME>.md`.
+> Try:
+> - "Make a 30-second video of yourself introducing what we're working on this week"
+> - "Send a video update to the team about today's progress"
+> - "Generate a video and POST the result to my webhook when done"
 
 The skill handles avatar resolution, prompt engineering, aspect ratio
 correction, voice selection, and Frame Check automatically. Give it a topic,


### PR DESCRIPTION
## What broke

Adam (HeyGen ops agent) ran the fresh install via the 2-line paste-prompt this morning. The install reported success — skills cloned, CLI installed, API key saved, transport detected. But:

- No `AVATAR-ADAM.md` was created.
- Workspace had `SOUL.md` and `IDENTITY.md` sitting unused.
- Adam wrapped at Step 8 ("Done") with no avatar to show for it.

User-facing expectation: *"my agent now has a face."* Actual outcome: *"the API works."* Those aren't the same thing.

## Root cause

Avatar creation lived in Step 6 ("Set agent-wide defaults (optional)") as a sub-bullet:

> "If the user has not created their own avatar yet, the heygen-avatar sub-skill walks them through..."

Two problems with that framing:

**1. Wrong default subject.** `heygen-avatar/SKILL.md` says explicitly:

> "Default target = the agent. The primary use of this skill is giving the agent a face + voice so it can present videos. For agent avatars: read SOUL.md and IDENTITY.md first, then go straight to prompt-based creation."

The install guide was treating avatar creation as a *user* concern ("the user's own avatar"). The sub-skill defaults to the *agent*. Adam never even considered creating his own avatar because the doc didn't say it was a thing.

**2. Optional, not mandatory.** Even if Adam had clicked through, "Step 6 (optional)" reads as skippable. The install's user-facing outcome is the agent having a presenter — that's not optional.

## Fix

New **Step 5: Give the agent a face (canonical install outcome)**, inserted between transport selection (old Step 4) and verify (old Step 5).

The step:

- **Defaults to the agent as subject** (matches `heygen-avatar/SKILL.md` Phase 0).
- **Branches on `SOUL.md` / `IDENTITY.md` presence:**
  - **Present** (OpenClaw workspace) → read identity files, prompt-based creation, save `AVATAR-<AGENT-NAME>.md` at workspace root.
  - **Absent** (Claude Code, Codex, Cursor, Hermes) → skill asks user for design direction directly.
- **Specifies skip conditions explicitly:**
  - User already has an `avatar_id` / `voice_id` they want to reuse.
  - Install scoped to stock-avatar usage only.
  - Both rare.

## Renumbering

| Old | New | Notes |
|-----|-----|-------|
| 5 | 6 | Verify (smoke test). Now references "the avatar from Step 5" instead of suggesting a stock avatar. |
| 6 | 7 | Defaults. Now reads "if you ran Step 5, you have avatar_id / voice_id — save them as defaults." |
| 7 | 8 | Make HeyGen the default video provider. |
| 8 | 9 | Done. Mentions `AVATAR-<NAME>.md` as the install artifact. |

## Cross-references fixed

Step 1 (ClawHub shortcut) and Step 2 (MCP detection) both said *"jump to Step 5 (verify)"* — both now correctly say *"Step 5 (avatar creation)."* Step 6 verify references the avatar created in Step 5. Step 7 defaults explicitly tie back to Step 5's output.

## Diff

`INSTALL_FOR_AGENTS.md` only. +83 / -29.

## Verification

Read `heygen-avatar/SKILL.md` end-to-end before drafting the new Step 5. The branching logic for `SOUL.md` presence + the "default target = agent" rule + the workspace-file save convention (`AVATAR-<NAME>.md`) all match what the sub-skill actually implements at Phase 0.

Did not run a fresh install with the new step — that would burn a real credit on the smoke test. Easy to verify post-merge: re-run Adam's paste-prompt, expect `AVATAR-ADAM.md` in his workspace at end-of-install.

## What this PR does NOT change

- No skill content changes (`SKILL.md`, `heygen-avatar/SKILL.md`, `heygen-video/SKILL.md` untouched).
- No transport changes.
- No README change. The 2-line paste-prompt still resolves to this file; the file's just better now.
