### PR TITLE
feat(avatar): role-based symlinks (AVATAR-AGENT.md, AVATAR-USER.md) for generic lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ Skills communicate through `AVATAR-<NAME>.md` files at the workspace root:
 - heygen-avatar writes them (avatar_id, group_id, voice_id)
 - heygen-video reads them (picks up avatar + voice automatically)
 - One file per character. Human-readable AND machine-readable.
+- heygen-avatar also maintains role-based symlinks (`AVATAR-AGENT.md`,
+  `AVATAR-USER.md`) pointing at the current agent / user named file, so
+  consumer skills can resolve generic self-references ("make a video of
+  yourself" / "my video update") without parsing identity files.
 
 ## API Conventions
 

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -199,15 +199,21 @@ The skill will:
 3. Generate the avatar via the Avatar V pipeline (prompt-based by default;
    photo opt-in only for real-person digital twins).
 4. Save `AVATAR-<AGENT-NAME>.md` at the workspace root for future reuse.
-5. Return `avatar_id` + `voice_id` for use in Step 7 (defaults).
+5. Maintain the `AVATAR-AGENT.md` symlink (or `AVATAR-USER.md` for
+   user-target installs) pointing at the named file, so generic
+   self-reference requests ("make a video of yourself" / "my video
+   update") resolve without name lookup.
+6. Return `avatar_id` + `voice_id` for use in Step 7 (defaults).
 
-On the happy path, this step ends with a new file like `AVATAR-EVE.md`,
-`AVATAR-ADAM.md`, or `AVATAR-CLEO.md` at the workspace root. That file is
-the persistent identity — every future video reuses it automatically. Note
-that the heygen-avatar skill has a Phase 2 STOP gate before generation; if
-the user aborts there, no file is written and no credits are spent. That's
-the correct behavior — it's a confirmation gate, not a bug. Resume by
-re-invoking the sub-skill.
+On the happy path, this step ends with both a named file (e.g.
+`AVATAR-EVE.md`, `AVATAR-ADAM.md`, `AVATAR-CLEO.md`) and a role-based
+symlink (`AVATAR-AGENT.md` for agent target, `AVATAR-USER.md` for user
+target) at the workspace root. Named files are canonical; symlinks are
+pointers that consumer skills (heygen-video) can read for generic
+self-reference. Note that the heygen-avatar skill has a Phase 2 STOP gate
+before generation; if the user aborts there, no file is written and no
+credits are spent. That's the correct behavior — it's a confirmation gate,
+not a bug. Resume by re-invoking the sub-skill.
 
 ### If you are running outside an OpenClaw workspace (no `SOUL.md`)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -158,7 +158,11 @@ Default to Full Producer. Better to ask one smart question than generate a medio
 
 **Runs once before Discovery on the first video request in a session.**
 
-Check for any `AVATAR-*.md` files in the workspace root.
+Check for any `AVATAR-*.md` files in the workspace root. The directory may
+also contain role-based **symlinks** (`AVATAR-AGENT.md`, `AVATAR-USER.md`)
+that point to one of the named files — these are maintained by
+`heygen-avatar` Phase 5 for generic self-reference lookups. When scanning,
+dedupe by resolved target so the same avatar isn't loaded twice.
 
 - **Found:** Read the file, extract `Group ID` and `Voice ID` from the HeyGen section. Pre-load as defaults for Discovery. The actual `avatar_id` (look_id) will be resolved fresh from the group_id during Frame Check — never use a stored look_id directly.
 - **Not found:** The user (or agent) has no avatar yet. Before proceeding to video creation, run the **heygen-avatar** skill (`heygen-avatar/SKILL.md` in this repo) to create one. Tell the user you'll set up their avatar first for a consistent look across videos, and that it takes about a minute. Communicate in `user_language`.

--- a/heygen-avatar/SKILL.md
+++ b/heygen-avatar/SKILL.md
@@ -152,6 +152,18 @@ Then check `AVATAR-<NAME>.md` at the workspace root:
 - **AVATAR file exists but HeyGen section empty** → skip to Phase 2.
 - **No AVATAR file** → proceed to Phase 1.
 
+**Role alias staleness check.** Before proceeding, also check whether the
+role alias for this target is already pointing at the right named file:
+
+- For **agent target**: read `AVATAR-AGENT.md` (follow symlink) and
+  compare to `AVATAR-<CURRENT-AGENT-NAME>.md`. If they differ (e.g.,
+  `AVATAR-AGENT.md` → `AVATAR-OLD-NAME.md` because the agent identity
+  changed since the last run), re-link in Phase 5 even if no other
+  changes are made. The named file is canonical, but the alias must
+  match the *current* identity, not the historical one.
+- For **user target**: same check on `AVATAR-USER.md`.
+- For **named character**: no alias to check.
+
 **Optional existing-avatar check** (only useful on the user path when the user might already have avatars in their HeyGen account). If Phase 0 target = **user** AND no `AVATAR-<USER>.md` exists, list their HeyGen avatars first:
 
 **MCP:** `list_avatar_groups(ownership=private)`
@@ -312,27 +324,44 @@ Based on the Phase 0 target:
 - **Named character** → no role alias. Named characters are referenced by
   name only (e.g., `AVATAR-CLEO.md`); they are not the agent or the user.
 
-**Implementation (atomic, replace-existing):**
+**Implementation (run from the workspace root, with fs-fallback):**
+
+The `cd` to workspace root is mandatory — bare relative paths in `ln -s`
+resolve from the agent's current working directory, not where SOUL.md
+lives. The `|| echo` clause handles filesystems that reject symlinks
+(Windows without dev mode, some cloud-mounted storage) without aborting
+Phase 5.
 
 ```bash
 # Agent
-ln -sf AVATAR-<NAME>.md AVATAR-AGENT.md
+cd "$WORKSPACE_ROOT" && ln -sf AVATAR-<NAME>.md AVATAR-AGENT.md \
+  || echo "role alias skipped: fs doesn't support symlinks"
 
 # User
-ln -sf AVATAR-<NAME>.md AVATAR-USER.md
+cd "$WORKSPACE_ROOT" && ln -sf AVATAR-<NAME>.md AVATAR-USER.md \
+  || echo "role alias skipped: fs doesn't support symlinks"
 ```
 
-`ln -sf` overwrites any existing symlink atomically. Always use a relative
-link target so the alias survives if the workspace is moved or copied.
+Use a relative link target (just the filename, no path prefix) so the
+alias survives if the workspace is moved or copied.
 
-**Why symlink, not copy:** drift impossible. The named file is canonical
-source of truth; the alias is a pointer. If the agent identity changes
-(rare — e.g., workspace reassignment), re-running this skill updates the
-symlink to the new named file.
+`ln -sf` is unlink-then-symlink under the hood, not strictly atomic.
+Fine for single-user workspaces; if concurrent agents ever write the
+same alias, expect interleaving and add explicit locking then.
 
-**Skip on platforms without symlink support.** If the underlying filesystem
-rejects the `ln -s` call, log a one-line note ("role alias skipped: fs
-doesn't support symlinks") and continue. The named file is still authoritative.
+**Why symlink, not copy:** removes the duplicate-file drift class
+(content can never diverge between named file and alias). It does NOT
+remove staleness drift — if `IDENTITY.md` changes the agent name without
+re-running heygen-avatar, `AVATAR-AGENT.md` keeps pointing at the *old*
+named file. Phase 0 mismatch-and-re-alias handles this on the next
+invocation; until then, the alias is stale-but-pointing-somewhere-valid,
+not broken.
+
+**Multi-agent workspace caveat:** one role alias per workspace is
+last-writer-wins. If two agents ever share a workspace and both run
+heygen-avatar, only the most recent run's identity is reachable via
+`AVATAR-AGENT.md`. Named files for both still exist. We accept this
+limit — multi-agent shared workspaces are out of scope for v1.
 
 ### Phase 6 — Test (Optional)
 

--- a/heygen-avatar/SKILL.md
+++ b/heygen-avatar/SKILL.md
@@ -70,10 +70,24 @@ Try to read `SOUL.md` from the workspace root.
 Every avatar gets one file: `AVATAR-<NAME>.md` at the workspace root.
 
 ```
-AVATAR-EVE.md      ← agent
-AVATAR-KEN.md      ← user
-AVATAR-CLEO.md     ← named character
+AVATAR-EVE.md      ← agent      (named, canonical)
+AVATAR-KEN.md      ← user       (named, canonical)
+AVATAR-CLEO.md     ← character  (named, canonical)
 ```
+
+The skill also maintains two **role-based symlinks** alongside the named
+files, for generic lookups by consumer skills (e.g., heygen-video) when the
+request doesn't carry a specific name ("make a video of yourself" → read
+the agent alias; "make a video of me" → read the user alias):
+
+```
+AVATAR-AGENT.md → AVATAR-<CURRENT-AGENT-NAME>.md   (symlink)
+AVATAR-USER.md  → AVATAR-<CURRENT-USER-NAME>.md    (symlink)
+```
+
+Named files are the single source of truth; aliases are pointers and never
+drift. Phase 5 of the workflow maintains them. Named characters get NO
+role alias — they are referenced by name only.
 
 Format:
 ```markdown
@@ -285,7 +299,42 @@ Update the HeyGen section of `AVATAR-<NAME>.md` to match the canonical format:
 
 Confirm the avatar is saved and that other skills (like heygen-video) will pick it up automatically. Communicate in `user_language`.
 
-### Phase 5 — Test (Optional)
+### Phase 5 — Maintain Role Alias
+
+After writing the named `AVATAR-<NAME>.md`, create or update a role-based
+symlink alongside it so other skills can do generic lookups without
+resolving the agent / user name first.
+
+Based on the Phase 0 target:
+
+- **Agent target** → symlink `AVATAR-AGENT.md` → `AVATAR-<NAME>.md`
+- **User target** → symlink `AVATAR-USER.md` → `AVATAR-<NAME>.md`
+- **Named character** → no role alias. Named characters are referenced by
+  name only (e.g., `AVATAR-CLEO.md`); they are not the agent or the user.
+
+**Implementation (atomic, replace-existing):**
+
+```bash
+# Agent
+ln -sf AVATAR-<NAME>.md AVATAR-AGENT.md
+
+# User
+ln -sf AVATAR-<NAME>.md AVATAR-USER.md
+```
+
+`ln -sf` overwrites any existing symlink atomically. Always use a relative
+link target so the alias survives if the workspace is moved or copied.
+
+**Why symlink, not copy:** drift impossible. The named file is canonical
+source of truth; the alias is a pointer. If the agent identity changes
+(rare — e.g., workspace reassignment), re-running this skill updates the
+symlink to the new named file.
+
+**Skip on platforms without symlink support.** If the underlying filesystem
+rejects the `ln -s` call, log a one-line note ("role alias skipped: fs
+doesn't support symlinks") and continue. The named file is still authoritative.
+
+### Phase 6 — Test (Optional)
 
 If the user wants to see their avatar in action:
 
@@ -313,7 +362,18 @@ Each iteration updates the AVATAR file. The file is always the source of truth.
 
 ## Video Producer Integration
 
-`heygen-video` reads AVATAR files for group_id and voice_id. "Make a video with Eve" → reads `AVATAR-EVE.md` → gets Group ID + Voice ID → resolves fresh look_id at runtime. No AVATAR file → falls back to stock avatars or asks user.
+`heygen-video` reads AVATAR files for group_id and voice_id. Resolution
+order:
+
+1. **Named request** ("Make a video with Eve") → read `AVATAR-EVE.md`.
+2. **Agent self-reference** ("make a video of yourself", "give us a video
+update") → read `AVATAR-AGENT.md` (symlink to current agent's named file).
+3. **User self-reference** ("make a video of me", "my video update") → read
+`AVATAR-USER.md` (symlink to current user's named file).
+4. **No AVATAR file or symlink** → fall back to stock avatars or ask user.
+
+The alias targets are resolved by the OS at read time, so consumer skills
+simply `cat AVATAR-AGENT.md` and get whatever the current agent's avatar is.
 
 ## Error Handling
 

--- a/heygen-video/SKILL.md
+++ b/heygen-video/SKILL.md
@@ -284,7 +284,28 @@ Snap cuts, flash frames. Zero breathing room.
 
 📖 **Full avatar discovery flow, creation APIs, voice selection → [../references/avatar-discovery.md](../references/avatar-discovery.md)**
 
-**Decision flow:**
+**AVATAR file resolution (run before any external avatar lookup):**
+
+If the request implies a specific subject, try the matching AVATAR file at
+the workspace root before browsing HeyGen catalogs.
+
+| Request signal | File to read |
+|---|---|
+| Named subject ("video with Eve", "Cleo's update") | `AVATAR-<NAME>.md` |
+| Agent self-reference ("video of yourself", "give us your update") | `AVATAR-AGENT.md` |
+| User self-reference ("video of me", "my video update") | `AVATAR-USER.md` |
+| No subject in request | (skip; ask in step 1 below) |
+
+`AVATAR-AGENT.md` and `AVATAR-USER.md` are role-based **symlinks**
+maintained by `heygen-avatar` Phase 5; they resolve to the current
+agent's / user's named AVATAR file at read time. Treat them like any
+other AVATAR file once read.
+
+If the AVATAR file (named or alias) exists and has a populated HeyGen
+section, extract `group_id` + `voice_id` and proceed to Frame Check. Skip
+the rest of the discovery flow.
+
+**Discovery flow (when no AVATAR file applies):**
 1. Ask: "Visible presenter or voice-over only?"
 2. If voice-over → no `avatar_id`, state in prompt.
 3. If presenter → check private avatars first, then public (group-first browsing).

--- a/references/avatar-discovery.md
+++ b/references/avatar-discovery.md
@@ -1,5 +1,34 @@
 # Avatar Discovery & Voice Selection
 
+## Path 0: Resolve workspace AVATAR files first
+
+Before any HeyGen catalog lookup, check the workspace root for an
+applicable `AVATAR-*.md` file. These are written by `heygen-avatar`
+and contain `Group ID` + `Voice ID` ready to use, with no API call
+needed.
+
+Resolution precedence:
+
+| Request signal | File to read |
+|---|---|
+| Named subject ("video with Eve", "Cleo's update") | `AVATAR-<NAME>.md` |
+| Agent self-reference ("video of yourself", "give us your update") | `AVATAR-AGENT.md` (symlink) |
+| User self-reference ("video of me", "my video update") | `AVATAR-USER.md` (symlink) |
+| No subject in request | Skip to Path A |
+
+`AVATAR-AGENT.md` and `AVATAR-USER.md` are role-based symlinks maintained
+by `heygen-avatar` Phase 5; they resolve to the current agent's / user's
+named AVATAR file at read time. Treat them like any other AVATAR file
+once read.
+
+If the resolved file has a populated HeyGen section, extract `Group ID`
+and `Voice ID` and proceed to Frame Check. Skip Path A entirely. If the
+file exists but the HeyGen section is empty, run `heygen-avatar` Phase 2
+first.
+
+If no file applies (no name match, no role alias, generic catalog
+browsing requested) — fall through to Path A below.
+
 ## Path A: Discover Existing Avatars
 
 ### A1: Check for private avatars first


### PR DESCRIPTION
Follow-up to #71 (avatar creation as first-class install step).

## Problem this solves

`heygen-video` does **name-based** lookup of AVATAR files:

> *"Make a video with Eve"* → reads `AVATAR-EVE.md`

That works when the request carries a name. But generic self-references don't carry one:

- *"make a video of yourself"* (agent target, but agent name not in scope until SOUL.md/IDENTITY.md parsed)
- *"make a video of me"* (user target, user name often not in workspace)

Today the calling skill has to:

1. Detect target (agent vs user) from phrasing
2. Resolve the name (parse `SOUL.md` / `IDENTITY.md` / `USER.md`)
3. Construct `AVATAR-<NAME>.md` path
4. Read the file

That's brittle. Identity files may be missing, multiple agent identities may exist in one workspace, or name parsing may fail.

## Fix

`heygen-avatar` Phase 5 (new) creates a role-based **symlink** alongside the named file:

```
AVATAR-AGENT.md → AVATAR-<CURRENT-AGENT>.md   (symlink)
AVATAR-USER.md  → AVATAR-<CURRENT-USER>.md    (symlink)
```

Named characters get **no role alias** — they are not the agent or the user.

Implementation: `ln -sf <target> <alias>`, atomic, with relative target paths so the alias survives workspace move/copy.

## Why symlinks, not duplicate files

**Drift impossible.** The named file is single source of truth; the alias is a pointer. If the agent identity changes (rare), re-running the skill updates the symlink to the new named file. Duplicate files would require replication on every change → drift potential the skill would have to defend against.

**Tradeoff:** filesystems without symlink support (Windows without dev mode, some cloud-mounted storage) skip the alias. The skill logs a one-line note and continues — named file is still authoritative.

## Resolution precedence in `heygen-video`

Updated `### Avatar` section now explicitly documents:

| Request signal | File to read |
|---|---|
| Named subject (`"video with Eve"`, `"Cleo's update"`) | `AVATAR-<NAME>.md` |
| Agent self-reference (`"video of yourself"`, `"give us your update"`) | `AVATAR-AGENT.md` |
| User self-reference (`"video of me"`, `"my video update"`) | `AVATAR-USER.md` |
| No subject | Skip; discovery flow |

The symlink targets resolve at read time, so consumer skills just `cat AVATAR-AGENT.md` and get whatever the current agent's avatar is.

## Files changed

- `heygen-avatar/SKILL.md` — Phase 5 (new), Avatar File Convention section updated, Video Producer Integration section updated. Old Phase 5 (Test) → Phase 6.
- `heygen-video/SKILL.md` — `### Avatar` section adds AVATAR file resolution table with precedence.
- `INSTALL_FOR_AGENTS.md` — Step 5 mentions the symlink as a sub-step.

**Diff:** +102 / -15 across 3 files.

## What this PR does NOT change

- Named `AVATAR-<NAME>.md` format is unchanged.
- `heygen-avatar` Phases 0-4 unchanged.
- Frame Check / Quick Shot rules in `heygen-video` unchanged.
- No transport / API key / config changes.
- No new APIs, no new dependencies.

## Testing

Did NOT run a fresh install with the new aliases — needs filesystem testing across at least 3 surfaces (macOS, Linux, Windows) and a real Phase 0-4 walk to verify the symlink lands at the right time. Recommend smoke testing in 1-2 real installs after merge before bumping version.

Suggested verification on merge:
1. Re-run Adam's paste-prompt → expect `AVATAR-ADAM.md` (named) + `AVATAR-AGENT.md` (symlink → AVATAR-ADAM.md) at workspace root
2. Test `heygen-video` with *"make a video of yourself"* — expect it to read `AVATAR-AGENT.md` and resolve to Adam's avatar without parsing SOUL.md
