### PR TITLE
fix(ci): use PAT for release-please so tag push fires publish.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT (or GitHub App token) instead of GITHUB_TOKEN so the
+          # tag push fires downstream workflows (publish.yml). GITHUB_TOKEN
+          # is intentionally scoped to NOT trigger workflow runs on tag
+          # push, to prevent recursive CI loops. We need that triggering
+          # behavior, so use a separate token.
+          # Falls back to GITHUB_TOKEN if RELEASE_PLEASE_TOKEN is unset, so
+          # this change is non-breaking until the secret is added.
+          # Ref: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
**Phase B / part 1.** Skills repo CI fix.

## Problem

GitHub Actions intentionally does not trigger downstream workflows when tags are pushed by `GITHUB_TOKEN`. This is documented behavior to prevent recursive CI loops:

> **Note:** Events triggered by the `GITHUB_TOKEN` will not create a new workflow run.
>
> *— [GitHub Actions docs: Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)*

For this repo: release-please tags `v*`, but `publish.yml` (triggered on tag push) never fires. Result: every release requires a manual republish to ClawHub.

**Concrete failure logs:**

| Tag | Created at | publish.yml fired? | Manual republish |
|-----|------------|---------------------|-------------------|
| v2.2.0 | 2026-04-27 14:49 UTC | ❌ No | Required at 15:03 UTC |
| v2.2.1 | 2026-04-27 18:23 UTC | ❌ No | Required at 18:25 UTC |

Same failure mode, two consecutive releases.

## Fix

Read the release-please token from a separate secret (`RELEASE_PLEASE_TOKEN`). Tag pushes from a PAT (not `GITHUB_TOKEN`) **do** trigger downstream workflows, so `publish.yml` will fire on every release-please-created tag.

```diff
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
```

Falls back to `GITHUB_TOKEN` if `RELEASE_PLEASE_TOKEN` is unset, so this PR is **non-breaking** until the secret is added. Merge first, then add the secret.

## Setup steps for repo admin (post-merge)

1. Generate a fine-grained PAT at: https://github.com/settings/personal-access-tokens/new
2. **Resource owner:** `heygen-com`
3. **Repository access:** "Only select repositories" → `heygen-com/skills`
4. **Permissions:**
   - Contents: read+write
   - Pull requests: read+write
   - Workflows: write (so release-please can edit workflow files when needed)
5. **Expiration:** 90 days (rotate quarterly — set a calendar reminder)
6. Add as repo secret: `Settings → Secrets and variables → Actions → New repository secret`, name `RELEASE_PLEASE_TOKEN`, paste the PAT value.

After the secret is added, the next release-please tag push will fire `publish.yml` automatically.

## Verification

After merge + secret add, monitor the next release:
1. Make any conventional commit on `master` (`fix:` / `feat:`).
2. Release-please opens a release PR (uses PAT, but no behavior change there).
3. Merge the release PR.
4. **Watch:** within ~30 seconds of the release PR merge, `publish.yml` should appear in Actions tab and run automatically.
5. Confirm with `clawhub inspect heygen-skills` — should show new version live within 5 minutes.

If `publish.yml` still doesn't fire after the secret is in place, the PAT scopes are wrong — re-check Contents/PRs/Workflows.

## What this PR does NOT change

- `publish.yml` itself unchanged.
- `release-please-config.json` and `.release-please-manifest.json` unchanged.
- No version bump.
- Plugin repo (`heygen-com/openclaw-plugin-heygen`) gets its own setup in a separate PR — that repo has zero CI today.

## Companion PR

This is **part 1 of Phase B**. Part 2 adds release-please.yml + publish.yml from scratch to `heygen-com/openclaw-plugin-heygen` (which has no CI today). Will post the link here once it's open.
