### PR TITLE
feat: reference HeyGen ChatGPT app for Codex plugin (replaces bundled MCP)

### DIFF
--- a/.app.json
+++ b/.app.json
@@ -1,0 +1,7 @@
+{
+  "apps": {
+    "heygen": {
+      "id": "asdk_app_69418aad55e08191aa5e437b649ca2e4"
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "avatar-video"
   ],
   "skills": "./",
-  "mcpServers": "./.mcp.json",
+  "apps": "./.app.json",
   "interface": {
     "displayName": "HeyGen",
     "shortDescription": "Avatar videos and personalized video messages",


### PR DESCRIPTION
## Summary

Per OpenAI directory feedback on [openai/plugins#192](https://github.com/openai/plugins/pull/192): plugins in the official Codex directory **cannot bundle their own MCP server**; they must reference a curated ChatGPT app from the catalog. HeyGen has [one live](https://chatgpt.com/apps/heygen/asdk_app_69418aad55e08191aa5e437b649ca2e4) (\`asdk_app_69418aad55e08191aa5e437b649ca2e4\`), so the Codex manifest now points at it.

## Changes

- **\`.app.json\`** (new, at repo root) — references the curated HeyGen ChatGPT app.
- **\`.codex-plugin/plugin.json\`** — swaps \`"mcpServers": "./.mcp.json"\` for \`"apps": "./.app.json"\`. Same shape as \`canva\` and \`hubspot\` in \`openai/plugins\`.

## What's NOT changing

The Claude Code and Cursor marketplaces don't have the same "no bundled MCP" rule, so:

- **\`.mcp.json\`** — kept (Claude Code auto-discovery)
- **\`mcp.json\`** — kept (Cursor auto-discovery)

Only the Codex manifest moves to the app reference.

## Companion PR

[\`openai/plugins#192\`](https://github.com/openai/plugins/pull/192) — the directory listing now matches.

## Test plan

- [x] All six manifests parse as JSON
- [x] \`.codex-plugin/plugin.json\` shape matches \`canva\` / \`hubspot\` reference plugins
- [x] App ID resolves: <https://chatgpt.com/apps/heygen/asdk_app_69418aad55e08191aa5e437b649ca2e4>
- [ ] Codex re-review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)