### PR TITLE
fix: shorten skill descriptions for Codex validation

### DIFF
--- a/heygen-avatar/SKILL.md
+++ b/heygen-avatar/SKILL.md
@@ -2,23 +2,7 @@
 version: 3.1.0 # x-release-please-version
 name: heygen-avatar
 description: |
-  Create a persistent HeyGen avatar — a reusable face + voice identity for the agent,
-  the user, or any named character — powered by HeyGen Avatar V technology.
-  Prompt-based creation by default (description → HeyGen builds it); photo upload is
-  optional for real-person digital twins.
-  Use when: (1) giving the agent a face + voice so it can present videos
-  ("bring yourself to life", "create your avatar", "give yourself an avatar",
-  "design a presenter", "set up an avatar", "let's make an avatar"),
-  (2) the user wants to appear in videos as themselves ("create my avatar",
-  "I want my face in a video", "digital twin of me", "build me an avatar"),
-  (3) building a named character presenter ("create an avatar called Cleo",
-  "design a character named X"), (4) establishing HeyGen identity before making videos —
-  the correct FIRST step when no avatar exists yet.
-  Chain signal: when the user says both an identity/avatar action AND a video action in the same
-  request ("create an avatar AND make a video", "set up identity THEN create a video",
-  "design a presenter AND immediately record"), run heygen-avatar first, then heygen-video.
-  Returns avatar_id + voice_id — pass directly to heygen-video to create HeyGen videos.
-  NOT for: generating videos (use heygen-video), translating videos, or TTS-only tasks.
+  Create a persistent HeyGen avatar: a reusable face and voice identity for the agent, the user, or a named character. Prompt-based by default; photo upload is optional for real-person digital twins. Use when setting up an avatar, creating a digital twin, building a character presenter, or establishing identity before a HeyGen video. If the user wants avatar creation and video generation in one request, run heygen-avatar first, then heygen-video. Not for generating videos, translating videos, or TTS-only tasks.
 argument-hint: "[name_or_description]"
 allowed-tools: Bash, WebFetch, Read, Write, mcp__heygen__*
 ---

--- a/heygen-video/SKILL.md
+++ b/heygen-video/SKILL.md
@@ -2,23 +2,7 @@
 version: 3.1.0 # x-release-please-version
 name: heygen-video
 description: |
-  Generate HeyGen presenter videos via the v3 Video Agent pipeline — handles Frame Check
-  (aspect ratio correction), prompt engineering, avatar resolution, and voice selection.
-  Required for any HeyGen video generation. Replaces deprecated endpoints with v3.
-  Use when: (1) generating any HeyGen video (via API or otherwise),
-  (2) sending a personalized video message (outreach, update, announcement, pitch, knowledge),
-  (3) creating a HeyGen presenter-led explainer, tutorial, or product demo with a human face,
-  (4) "make a video of me saying...", "send a video to my leads", "record an update for my team",
-  "create a video pitch", "make a loom-style message", "I want to appear in this video",
-  "generate a HeyGen video", "make a talking head video".
-  Accepts avatar_id from heygen-avatar for identity-first HeyGen videos, or uses a stock presenter.
-  Returns video share URL + HeyGen session URL for iteration.
-  Chain signal: when the user wants to create/design an avatar AND make a video in the same request,
-  run heygen-avatar first, then return here. Conjunctions to watch: "and then", "and immediately",
-  "first...then", "X and make a video", "design [presenter] and record" = always CHAIN.
-  If the user provides a photo AND wants a video, route to heygen-avatar first.
-  NOT for: avatar creation or identity setup (use heygen-avatar first), cinematic footage
-  or b-roll without a presenter, translating videos, TTS-only, or streaming avatars.
+  Generate HeyGen presenter videos via the v3 Video Agent pipeline. Use when generating any HeyGen video, sending a personalized video message, or creating a presenter-led explainer, tutorial, pitch, update, or product demo with a human face. Accepts avatar_id from heygen-avatar for identity-first videos or uses a stock presenter. If the user wants to create an avatar and make a video in the same request, run heygen-avatar first. Not for avatar creation, cinematic b-roll without a presenter, video translation, TTS-only, or streaming avatars.
 argument-hint: "[topic_or_script] [--avatar avatar_id]"
 homepage: https://developers.heygen.com/docs/quick-start
 allowed-tools: Bash, WebFetch, Read, Write, mcp__heygen__*


### PR DESCRIPTION
## Summary
- shorten heygen-avatar and heygen-video frontmatter descriptions below Codex's 1024-character validation limit
- keep the full skill instructions unchanged below frontmatter

## Validation
- heygen-video description length: 546 characters
- heygen-avatar description length: 515 characters
- verified post-frontmatter skill bodies are byte-for-byte identical by SHA-256 before and after the change