### PR TITLE
fix(cli-refs): correct video-agent/avatar-looks get to positional args

### DIFF
--- a/heygen-video/SKILL.md
+++ b/heygen-video/SKILL.md
@@ -523,7 +523,7 @@ From the response, pick the look matching the target orientation. Use the first 
 
 ### Steps
 
-1. **Fetch avatar look metadata:** `get_avatar_look(look_id=<avatar_id>)` (CLI: `heygen avatar looks get --look-id <avatar_id>`) → extract `avatar_type`, `preview_image_url`, `image_width`, `image_height`
+1. **Fetch avatar look metadata:** `get_avatar_look(look_id=<avatar_id>)` (CLI: `heygen avatar looks get <avatar_id>`) → extract `avatar_type`, `preview_image_url`, `image_width`, `image_height`
 2. **Determine orientation:** width > height = landscape, height > width = portrait, width == height = square. Fetch fails = assume portrait.
 3. **Determine background:** `photo_avatar` → Video Agent handles environment. `studio_avatar` → check if transparent/solid/empty. `video_avatar` → always has background.
 4. **Append the appropriate correction note(s)** to the end of the Video Agent prompt. That's it. No image generation, no new looks.
@@ -615,14 +615,14 @@ heygen video-agent create \
   --wait --timeout 45m
 ```
 
-The CLI returns JSON on stdout: `{"data": {"video_id": "...", "session_id": "..."}}` after submission. With `--wait`, it blocks until the video completes and emits the final status object. Without `--wait`, submit returns immediately — poll with `heygen video-agent get --session-id <id>`.
+The CLI returns JSON on stdout: `{"data": {"video_id": "...", "session_id": "..."}}` after submission. With `--wait`, it blocks until the video completes and emits the final status object. Without `--wait`, submit returns immediately — poll with `heygen video-agent get <id>`.
 
 **⚠️ Always capture `session_id` immediately.** Session URL: `https://app.heygen.com/video-agent/{session_id}`. Cannot be recovered later.
 
 ### Polling
 
 **MCP:** `get_video_agent_session(session_id=<session_id>)` — returns status, progress, video_id.
-**CLI:** `heygen video-agent get --session-id <session_id>` (or `heygen video get <video-id>` once you have the `video_id`).
+**CLI:** `heygen video-agent get <session_id>` (or `heygen video get <video-id>` once you have the `video_id`).
 
 Total wall time per video: **20–45 minutes**. If you passed `--wait`, the CLI handles polling with exponential backoff. If polling manually: first check at **5 min**, then every **60s** up to 45 min.
 

--- a/heygen-video/references/avatar-discovery.md
+++ b/heygen-video/references/avatar-discovery.md
@@ -70,7 +70,7 @@ Avatar types: `studio_avatar`, `video_avatar`, `photo_avatar`. Photo avatars sup
 Check `heygen-video-log.jsonl` for last used avatar_id. If found:
 
 **MCP:** `get_avatar_look(look_id=<look_id>)`
-**CLI:** `heygen avatar looks get --look-id <look_id>`
+**CLI:** `heygen avatar looks get <look_id>`
 
 Show preview image: "Last time you used [Avatar Name]. Use her again?"
 

--- a/heygen-video/references/frame-check.md
+++ b/heygen-video/references/frame-check.md
@@ -5,7 +5,7 @@ Runs automatically when `avatar_id` is set, before Generate. Appends correction 
 ## Step 1: Fetch the avatar look metadata
 
 **MCP:** `get_avatar_look(look_id=<avatar_id>)`
-**CLI:** `heygen avatar looks get --look-id <avatar_id>`
+**CLI:** `heygen avatar looks get <avatar_id>`
 
 Extract:
 - `avatar_type`: `"photo_avatar"` | `"studio_avatar"` | `"video_avatar"`

--- a/platforms/nanoclaw/heygen/SKILL.md
+++ b/platforms/nanoclaw/heygen/SKILL.md
@@ -57,7 +57,7 @@ With `--wait`, the CLI blocks until the video completes and emits the final stat
 ### Step 5: Poll for Completion (only without `--wait`)
 
 ```bash
-heygen video-agent get --session-id SESSION_ID | jq '{status: .data.status, video_url: .data.video_url}'
+heygen video-agent get SESSION_ID | jq '{status: .data.status, video_url: .data.video_url}'
 ```
 
 Poll every 15 seconds. Status progression: `pending` → `processing` → `completed`.


### PR DESCRIPTION
## Scope

**Affected skills:** `heygen-video` (SKILL.md + Frame Check / avatar-discovery references) and the NanoClaw `heygen` platform skill. **Area:** CLI command references.

## Summary

Two documented `heygen` CLI invocations use a flag form the CLI does not accept (verified on stable v0.4.0), so an agent following the skill literally hits a usage error instead of polling / fetching avatar metadata.

## Root cause

`heygen video-agent get` and `heygen avatar looks get` take the id as a **positional** argument (they are generated from the API path parameter). The skills wrote them with `--session-id` / `--look-id` flags, which do not exist. The CLI rejects unknown flags:

```
$ heygen video-agent get --session-id abc123
{"error":{"code":"usage_error","message":"unknown flag: --session-id"}}   # exit 2

$ heygen avatar looks get --look-id abc123
{"error":{"code":"usage_error","message":"unknown flag: --look-id"}}      # exit 2
```

This breaks the Video Agent manual-poll step and the Frame Check avatar-metadata fetch. Note the repo's own `heygen-video/references/troubleshooting.md` already uses the correct positional form, so this was an internal inconsistency, not a CLI change.

## Fix

Rewrite the six occurrences to positional form:
- `heygen video-agent get --session-id <id>` → `heygen video-agent get <id>`
- `heygen avatar looks get --look-id <id>` → `heygen avatar looks get <id>`

## Testing

Verified against the HeyGen CLI **stable v0.4.0**: the flag forms return `unknown flag` (exit 2); the positional forms match the documented usage (`heygen video-agent get <session-id>`, `heygen avatar looks get <look-id>`). Repo-wide grep confirms no remaining `--session-id` / `--look-id` occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
