### PR TITLE
fix(heygen-translate): correct translation states/fields, SRT asset upload, stale commands

### DIFF
--- a/heygen-translate/SKILL.md
+++ b/heygen-translate/SKILL.md
@@ -244,7 +244,7 @@ Use `--wait` on `create` to block until completion when running ONE language. Fo
 ```bash
 # CLI mode polling (background)
 heygen video-translate get <video-translation-id>
-# Returns { data: { status: "pending"|"running"|"succeeded"|"failed", video_url, ... } }
+# Returns { data: { status: "pending"|"running"|"completed"|"failed", video_url, ... } }
 ```
 
 Polling cadence: 30s for the first 3 minutes, then 60s. Most translations complete in 5–15 min; some (long videos, batched languages) take 30+ min. Hard timeout: 60 min per translation — beyond that, treat as stuck and surface the issue.
@@ -282,13 +282,12 @@ curl -s "$SRT_URL" -o /tmp/proofread.srt
 # 4. Edit /tmp/proofread.srt by hand or sed (glossary, register, names)
 #    See references/proofreads-workflow.md for the full edit playbook.
 
-# 5. Host the edited SRT at a public URL, then upload by reference.
-#    ⚠️  asset_id route is currently BLOCKED for SRTs —
-#       `heygen asset create` only accepts png/jpeg/mp4/webm/mp3/wav/pdf.
-#       Use the URL route. (gist raw, S3 public-read, presigned ≥2h, etc.)
-EDITED_URL="https://example.com/proofread-edited.srt"
+# 5. Upload the edited SRT as an asset, then reference it by asset_id.
+#    `heygen asset create` accepts srt (png, jpeg, mp4, webm, mp3, wav, pdf, srt).
+#    Fallback: host at a public URL and use {"type":"url","url":"..."}.
+ASSET_ID=$(heygen asset create --file /tmp/proofread.srt | jq -r '.data.asset_id')
 heygen video-translate proofreads srt update <proofread-id> \
-  -d "{\"srt\":{\"type\":\"url\",\"url\":\"$EDITED_URL\"}}"
+  -d "{\"srt\":{\"type\":\"asset_id\",\"asset_id\":\"$ASSET_ID\"}}"
 
 # 6. Kick off final render — returns a video_translation_id
 heygen video-translate proofreads generate <proofread-id> --captions
@@ -296,7 +295,7 @@ heygen video-translate proofreads generate <proofread-id> --captions
 
 # 7. Poll the translation to completion (NOT proofreads get — graduates here)
 heygen video-translate get <vid-id>
-# → status: running → succeeded; data.video_url has the final mp4
+# → status: running → completed; data.video_url has the final mp4
 ```
 
 📖 **When to insist on proofread, common SRT edits, glossary discipline → [references/proofreads-workflow.md](references/proofreads-workflow.md)**

--- a/heygen-translate/references/asset-routing.md
+++ b/heygen-translate/references/asset-routing.md
@@ -72,10 +72,10 @@ Red flags:
 
 ```bash
 heygen asset create --file /path/to/video.mp4
-# returns {"data":{"id":"<asset-id>","name":"...","url":"https://..."}}
+# returns {"data":{"asset_id":"<asset-id>","url":"https://...","mime_type":"...","size_bytes":123}}
 ```
 
-Capture `data.id` and pass as:
+Capture `.data.asset_id` and pass as:
 
 ```json
 { "type": "asset_id", "asset_id": "<id>" }
@@ -149,7 +149,7 @@ source video, use it directly:
 To verify an asset exists:
 
 ```bash
-heygen asset list 2>/dev/null | jq -r --arg id "abc123..." '.data[] | select(.id == $id) | .name'
+heygen asset get "abc123..." 2>/dev/null | jq -r '.data.name'
 ```
 
 If the asset is not in the user's account (different account, deleted), re-upload.

--- a/heygen-translate/references/proofreads-workflow.md
+++ b/heygen-translate/references/proofreads-workflow.md
@@ -165,24 +165,19 @@ Busco a alguien.
 - `proofread-id` as positional argument
 - `srt` body: `{type: "url", url: "..."}` or `{type: "asset_id", asset_id: "..."}`
 
-**Verified upload behavior:**
+**Upload behavior:**
 
-✅ **URL route works.** Host the edited SRT at any publicly reachable URL and pass `{type:"url", url:"..."}`.
+✅ **`asset_id` route works (preferred).** `heygen asset create` accepts SRT (supported types: `png, jpeg, mp4, webm, mp3, wav, pdf, srt`). Upload the edited SRT, capture `.data.asset_id`, and pass `{type:"asset_id", asset_id:"..."}`:
 
-⚠️ **`asset_id` route is currently blocked for SRT files.** `heygen asset create` only accepts `png, jpeg, mp4, webm, mp3, wav, pdf` — uploading an SRT (MIME `application/x-subrip`) returns:
-
-```json
-{
-  "error": {
-    "code": "invalid_parameter",
-    "message": "Content type not supported application/x-subrip"
-  }
-}
+```bash
+ASSET_ID=$(heygen asset create --file /tmp/proofread.srt | jq -r '.data.asset_id')
+heygen video-translate proofreads srt update <proofread-id> \
+  -d "{\"srt\":{\"type\":\"asset_id\",\"asset_id\":\"$ASSET_ID\"}}"
 ```
 
-This is true regardless of file extension (renaming `.srt` to `.txt` or `.mp3` does not bypass it — the server sniffs content). The `asset_id` route is in the request schema but you cannot currently produce a HeyGen `asset_id` for an SRT through the standard upload path. **Use the URL route.**
+✅ **URL route works (fallback).** Host the edited SRT at any publicly reachable URL and pass `{type:"url", url:"..."}`. (Non-subtitle content-type mismatches still error on upload.)
 
-**Practical patterns for hosting the edited SRT:**
+**Practical patterns for hosting the edited SRT (URL route):**
 
 | Where the SRT lives | How to make it reachable |
 |---------------------|--------------------------|
@@ -264,10 +259,11 @@ curl -s "$ORIG_URL" -o /tmp/proofread-original.srt
 sed -i 's/Centro Garra/ClawHub/g'        /tmp/proofread.srt
 sed -i 's/José Joshua/Joshua Xu/g'       /tmp/proofread.srt
 
-# 5. Host the edited SRT at a public URL, then upload by reference
-EDITED_URL="https://example.com/proofread-edited.srt"
+# 5. Upload the edited SRT as an asset, then reference it by asset_id
+#    (fallback: host at a public URL and use {"type":"url","url":"..."})
+ASSET_ID=$(heygen asset create --file /tmp/proofread.srt | jq -r '.data.asset_id')
 heygen video-translate proofreads srt update <proofread-id> \
-  -d "{\"srt\":{\"type\":\"url\",\"url\":\"$EDITED_URL\"}}"
+  -d "{\"srt\":{\"type\":\"asset_id\",\"asset_id\":\"$ASSET_ID\"}}"
 # → returns the proofread resource (status still completed)
 
 # 6. Kick off the final render with the corrected captions
@@ -276,7 +272,7 @@ heygen video-translate proofreads generate <proofread-id> --captions
 
 # 7. Poll the resulting translation to completion
 heygen video-translate get <vid-id>
-# → status: running → succeeded; data.video_url has the final mp4
+# → status: running → completed; data.video_url has the final mp4
 ```
 
 ---
@@ -395,7 +391,7 @@ Cost: HeyGen bills the final render the same as a non-proofread translation. The
 |---------|----------------------------|-------|-----|
 | `failed` immediately on submit | `Failed to download video from url, please check the url is valid or the video is public` | Source URL was 401/403/404, returned HTML, redirected to a login page, or had wrong MIME | HEAD-check the URL with `curl -sI`; ask user for public URL or local file → upload route |
 | `failed` after ~30 s of `processing` | `Your video's audio is missing or corrupted, please try with another video` | Source has no audible speech, audio track is silent / missing, or codec is unparseable | Verify the source has speech; consider re-encoding to MP4 + AAC; for silent / animation-only sources, route to a different workflow (this skill won't help) |
-| SRT update returns `Content type not supported application/x-subrip` | (CLI error envelope, not API status) | You tried to upload the edited SRT via `heygen asset create` — that endpoint only accepts png/jpeg/mp4/webm/mp3/wav/pdf | Host the SRT at a public URL and use `srt update -d '{"srt":{"type":"url","url":"..."}}'` |
+| `asset create` returns `Content type not supported ...` | (CLI error envelope, not API status) | The uploaded file's sniffed content type isn't a supported type (`png/jpeg/mp4/webm/mp3/wav/pdf/srt`) — e.g. a mislabeled or non-subtitle file | Upload a real `.srt` via `heygen asset create --file <x.srt>` and pass `{type:"asset_id",...}`, or use the URL route |
 | Uploaded SRT timing is off | n/a — bad render result | SRT timecodes were edited or shifted | Re-download the SRT from `proofreads srt get` and edit text only, never timecodes; re-upload |
 | `generate` runs but final render uses old text | n/a | `srt update` didn't take or you forgot to call it before `generate` | Re-upload, then re-call `proofreads generate` |
 | Proofread session expired | session not found | Sessions have a TTL (typically 24 h) | Re-create the proofread; don't try to revive an expired one |
@@ -406,9 +402,9 @@ For other failure_message strings, see [troubleshooting.md](troubleshooting.md#e
 
 ## Caveats and known quirks (verified)
 
-- **`heygen asset create` does not accept SRT files.** Only `png/jpeg/mp4/webm/mp3/wav/pdf`. Renaming the extension does not bypass it (server sniffs content). The `asset_id` shape is in the request schema for `srt update` for forward-compatibility, but the upload path is currently blocked. Use the URL route.
+- **`heygen asset create` accepts SRT files.** Supported types: `png/jpeg/mp4/webm/mp3/wav/pdf/srt`. Upload the edited SRT, capture `.data.asset_id`, and pass `{type:"asset_id",...}` to `srt update` (preferred); the URL route remains a fallback.
 - **`proofreads create` returns `proofread_ids` (plural, one per language) and a `status` at the SESSION level.** The session-level `status` is just the submit ack; per-id status comes from `proofreads get`.
-- **`status` enum is `processing | completed | failed`.** Not `pending` / `running`. (The translation-render endpoint uses `pending | running | succeeded | failed` — these are different state machines.)
+- **`status` enum is `processing | completed | failed`.** Not `pending` / `running`. (The translation-render endpoint uses `pending | running | completed | failed` — these are different state machines.)
 - **`original_srt_url`** is auto-populated even when no SRT was provided at create time. It's the engine's source-language transcription, not a copy of an SRT you uploaded. Useful for verification, never re-upload as a target-language SRT.
 - **SRT filenames carry the title.** The downloaded SRTs are named `<title>_proofread.srt` and `<title>_proofread_original.srt`. Pick a clean, fileNAME-safe `--title`.
 - **Polling shifts after `generate`.** Up through `srt update`, you poll `heygen video-translate proofreads get`. After `generate` returns a `video_translation_id`, you poll `heygen video-translate get` instead — same translation poll loop as a non-proofread workflow.

--- a/heygen-translate/references/troubleshooting.md
+++ b/heygen-translate/references/troubleshooting.md
@@ -40,7 +40,7 @@ heygen video-translate create -d '...' \
   > /tmp/translation-batch.json
 
 # Extract IDs
-jq -r '.data.video_translations[].video_translation_id' /tmp/translation-batch.json
+jq -r '.data.video_translation_ids[]' /tmp/translation-batch.json
 ```
 
 For each ID, run a backgrounded poll loop in a single shell invocation so the
@@ -53,13 +53,13 @@ while true; do
   resp=$(heygen video-translate get "$ID" 2>/dev/null)
   status=$(echo "$resp" | jq -r '.data.status')
   case "$status" in
-    succeeded)
-      url=$(echo "$resp" | jq -r '.data.video_url // .data.translated_video_url // empty')
+    completed)
+      url=$(echo "$resp" | jq -r '.data.video_url // empty')
       echo "DONE $LANG $url"
       break
       ;;
     failed)
-      msg=$(echo "$resp" | jq -r '.data.failure_reason // "unknown"')
+      msg=$(echo "$resp" | jq -r '.data.failure_message // "unknown"')
       echo "FAILED $LANG $msg"
       break
       ;;
@@ -106,7 +106,7 @@ heygen video-translate create -d '...' \
 `HEYGEN_API_KEY` is missing, expired, or wrong. Action:
 
 1. Confirm the env var: `echo "${HEYGEN_API_KEY:0:8}…" `
-2. Test with a known-good call: `heygen user`
+2. Test with a known-good call: `heygen user me get`
 3. If that fails, regenerate the key at <https://app.heygen.com/api>
 
 **`heygen auth login` worked but a call says `unauthorized`:**
@@ -172,12 +172,12 @@ Fails fast (~30 s after submit). Verify by previewing the source. If the user sa
 **`failed` with `failure_message: "Failed to download video from url, please check the url is valid or the video is public"`** (verified empirically):
 Fails almost instantly on submit. Source URL was 401/403/404, returned HTML instead of a video, redirected to a login page, or had a presigned URL that already expired. HEAD-check first with `curl -sI "$URL"` — expect `200` + `Content-Type: video/...`. Ask the user for a public URL or fall back to local-file upload.
 
-**`failed` with `failure_reason: "speaker detection"`:**
+**`failed` with `failure_message: "speaker detection"`:**
 `speaker_num` mismatched the actual speakers, or audio was too noisy for
 diarization. Re-submit with correct speaker count and
 `enable_speech_enhancement: true`.
 
-**`failed` with `failure_reason: "lip-sync"`:**
+**`failed` with `failure_message: "lip-sync"`:**
 Face was not detected or detection was unstable. Likely cause: occlusion,
 profile shots, low resolution, or fast cuts. Either:
 
@@ -197,23 +197,28 @@ long source videos or batched languages. Beyond 60 min, treat as stuck:
    another 30 minutes?"*
 3. If they re-submit, `heygen video-translate delete <id>` first.
 
-### SRT upload errors (proofreads workflow)
+### SRT upload (proofreads workflow)
 
-**`heygen asset create` returns `Content type not supported application/x-subrip` when uploading an edited SRT** (verified):
-The asset upload endpoint only accepts `png/jpeg/mp4/webm/mp3/wav/pdf`. SRT files are not supported regardless of extension (server sniffs content; renaming `.srt` to `.txt` or `.mp3` does NOT bypass it). The `asset_id` shape is in the `srt update` request schema for forward-compatibility but the upload path is currently blocked.
+**Preferred: upload the edited SRT as an asset.** `heygen asset create` accepts `srt` (supported types: `png, jpeg, mp4, webm, mp3, wav, pdf, srt`). Upload the file, capture `.data.asset_id`, and pass it to `srt update`:
 
-**Fix:** host the edited SRT at a public URL and use the URL route:
+```bash
+ASSET_ID=$(heygen asset create --file /path/to/proofread-edited.srt | jq -r '.data.asset_id')
+heygen video-translate proofreads srt update <proofread-id> \
+  -d "{\"srt\":{\"type\":\"asset_id\",\"asset_id\":\"$ASSET_ID\"}}"
+```
+
+**Fallback: public URL route.** If you'd rather host the SRT, use the URL form:
 
 ```bash
 heygen video-translate proofreads srt update <proofread-id> \
   -d '{"srt":{"type":"url","url":"https://example.com/proofread-edited.srt"}}'
 ```
 
-Working host options: GitHub gists (raw URL), GitHub repo files (raw URL), S3/GCS with public-read or a presigned URL ≥2 h, Vercel/static hosts. The URL must serve `application/x-subrip` or `text/plain` with the SRT body — verify with `curl -sI`.
+Working host options: GitHub gists (raw URL), GitHub repo files (raw URL), S3/GCS with public-read or a presigned URL ≥2 h, Vercel/static hosts. The URL must serve `application/x-subrip` or `text/plain` with the SRT body — verify with `curl -sI`. (Non-subtitle content-type mismatches still error on upload.)
 
 ### Output / delivery errors
 
-**`succeeded` but `video_url` is null:**
+**`completed` but `video_url` is null:**
 Race condition between job completion and CDN propagation. Retry the `get`
 call after 30 seconds.
 
@@ -246,13 +251,13 @@ speaker count, or use proofreads to scrub the SRT and re-dub.
 
 ## Debug Checklist (run before escalating)
 
-1. **Auth:** `heygen user` returns user info ✅ / fails ❌
+1. **Auth:** `heygen user me get` returns user info ✅ / fails ❌
 2. **CLI version:** `heygen --version` returns v0.0.6 or newer
 3. **Languages list:** `heygen video-translate languages list | jq '.data.languages | length'` returns >0
 4. **Source URL reachable:** `curl -sI "<URL>" | head -1` returns `200`
 5. **Source MIME:** `curl -sI "<URL>" | grep -i content-type` shows `video/...`
 6. **Recent jobs:** `heygen video-translate list` to see if past jobs succeeded
 
-If all six pass and the translation still fails: capture the `failure_reason`
+If all six pass and the translation still fails: capture the `failure_message`
 from `heygen video-translate get <id>` and surface it — that's HeyGen-side, not
 something the skill can resolve.


### PR DESCRIPTION
## Scope

**Skill:** `heygen-translate` (SKILL.md + `references/{asset-routing,proofreads-workflow,troubleshooting}.md`). **Area:** stale CLI state-machine / field / command references. Stacked on the heygen-avatar audit PR (→ #92).

## Fixes (verified against stable v0.4.0 schemas)

- **Translation-job terminal state & fields:** `succeeded` → `completed` (the `video-translate get` status enum is `pending | running | completed | failed`); `failure_reason` → `failure_message`; dropped the non-existent `translated_video_url` fallback (use `.data.video_url`). The prior poll loops never exited on success. (Proofread-*session* states `processing | completed | failed` left unchanged — separate state machine.)
- **Batch-create response field:** `.data.video_translations[].video_translation_id` → `.data.video_translation_ids[]`.
- **`asset create` response:** `.data.id` / `name` → `.data.asset_id` / `url` / `mime_type` / `size_bytes`; capture `.data.asset_id`.
- **Non-existent command:** `heygen asset list` → `heygen asset get <id>`.
- **`heygen user`** (help only) → `heygen user me get`.
- **SRT upload (STALE claim reversed):** the docs said `heygen asset create` rejects SRT and the `asset_id` path is "blocked". Stable v0.4.0 **supports** `srt` (`png, jpeg, mp4, webm, mp3, wav, pdf, srt`). Rewrote the proofread flow to upload the edited SRT and pass `{"type":"asset_id",…}`; kept the public-URL route as a fallback.

## Testing

Verified every state/field/command against the stable v0.4.0 binary (`--response-schema` / `--help`). No live API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
