### PR TITLE
feat(skills): report CLI feedback after each task

### DIFF
--- a/heygen-avatar/SKILL.md
+++ b/heygen-avatar/SKILL.md
@@ -410,6 +410,19 @@ If the user wants to see their avatar in action:
 
 Generate a natural greeting in the video language (from `user_language`). Examples: English "Hi, I'm [name]. Nice to meet you!", Japanese "[name]です。はじめまして！", Spanish "Hola, soy [name]. ¡Mucho gusto!", Korean "안녕하세요, [name]입니다. 만나서 반갑습니다!"
 
+## Report feedback (CLI mode)
+
+Once the avatar and voice are saved — or if you hit friction along the way — run this once per task:
+
+```bash
+heygen feedback --rating <1-5> --comment "<what worked, or what broke and what you tried>"
+```
+
+- `--rating`: `5` = worked great · `3` = worked with friction · `1` = broke / unusable.
+- `--comment`: any bug, stale doc, missing flag, or confusing behavior, plus the command or flow that triggered it.
+
+Anonymous, needs no API key, and no-ops when analytics are opted out (`HEYGEN_NO_ANALYTICS` or `heygen config set analytics false`). This is the CLI team's main signal channel — a run that finishes silently tells them nothing. **CLI mode only:** skip in MCP or OpenClaw-plugin mode (those route through the MCP/plugin surface, which has no feedback command).
+
 ## Iteration Flow
 
 When the user wants to refine:

--- a/heygen-translate/SKILL.md
+++ b/heygen-translate/SKILL.md
@@ -311,6 +311,19 @@ If a language failed: one short line with the cause (from troubleshooting refere
 
 **Source-quality disclaimer.** Translation can't improve on the source. If the source has muffled audio, fast cuts, heavy occlusion of the face, or low resolution, lip-sync and voice quality will degrade. When you detect these conditions in Phase 2 (or the user mentions them), warn upfront. Don't surface this *after* a bad result.
 
+### Report feedback (CLI mode)
+
+Once the translation is delivered — or if you hit friction along the way — run this once per task:
+
+```bash
+heygen feedback --rating <1-5> --comment "<what worked, or what broke and what you tried>"
+```
+
+- `--rating`: `5` = worked great · `3` = worked with friction · `1` = broke / unusable.
+- `--comment`: any bug, stale doc, missing flag, or confusing behavior, plus the command or flow that triggered it.
+
+Anonymous, needs no API key, and no-ops when analytics are opted out (`HEYGEN_NO_ANALYTICS` or `heygen config set analytics false`). This is the CLI team's main signal channel — a run that finishes silently tells them nothing. **CLI mode only:** skip in MCP or OpenClaw-plugin mode (those route through the MCP/plugin surface, which has no feedback command).
+
 ---
 
 ## Embedded Expertise

--- a/heygen-video/SKILL.md
+++ b/heygen-video/SKILL.md
@@ -655,6 +655,19 @@ After EVERY generation, append to `heygen-video-log.jsonl`:
 
 If user wants changes: adjust prompt based on feedback, re-generate. Never retry with the exact same prompt.
 
+### Report feedback (CLI mode)
+
+Once the video is delivered — or if you hit friction along the way — run this once per task:
+
+```bash
+heygen feedback --rating <1-5> --comment "<what worked, or what broke and what you tried>"
+```
+
+- `--rating`: `5` = worked great · `3` = worked with friction · `1` = broke / unusable.
+- `--comment`: any bug, stale doc, missing flag, or confusing behavior, plus the command or flow that triggered it.
+
+Anonymous, needs no API key, and no-ops when analytics are opted out (`HEYGEN_NO_ANALYTICS` or `heygen config set analytics false`). This is the CLI team's main signal channel — a run that finishes silently tells them nothing. **CLI mode only:** skip in MCP or OpenClaw-plugin mode (those route through `mcp__heygen__*` / `video_generate`, which have no feedback surface).
+
 ---
 
 ## Best Practices

--- a/platforms/nanoclaw/heygen/SKILL.md
+++ b/platforms/nanoclaw/heygen/SKILL.md
@@ -82,6 +82,16 @@ After generating a video, confirm:
 3. `heygen video get <video_id>` returns a valid HTTPS `.data.video_url`
 4. Downloaded file is a playable MP4
 
+## Report Feedback
+
+After the video is delivered and verified, report how the run went (once per task):
+
+```bash
+heygen feedback --rating <1-5> --comment "<what worked, or what broke>"
+```
+
+`--rating` runs 1 (broke / unusable) to 5 (worked great); put any bug or friction in `--comment`. Anonymous, no API key; no-ops if analytics are opted out (`HEYGEN_NO_ANALYTICS` or `heygen config set analytics false`).
+
 ## Troubleshooting
 
 | Symptom | Fix |


### PR DESCRIPTION
## Scope

**Surfaces:** agent skills (heygen-video, heygen-avatar, heygen-translate, and the NanoClaw platform variant). **Area:** feedback reporting.

## Summary

Adds a "report feedback" step to each CLI-using skill so an agent runs `heygen feedback --rating <1-5> --comment "..."` once per task, mirroring how the HyperFrames skills use `hyperframes feedback`. This turns every agent-driven run into a signal for the CLI team.

## How it works

`heygen feedback` (stable v0.4.0) sends an anonymous satisfaction rating (1–5) plus an optional comment as an analytics event — no API key, and it honors the same opt-out as usage analytics (`HEYGEN_NO_ANALYTICS` / `heygen config set analytics false`). Each skill now ends its delivery flow with a one-shot feedback call: `5` = worked great, `3` = friction, `1` = broke; the `--comment` carries any bug, stale doc, missing flag, or confusing behavior plus the command/flow that triggered it.

## Design decisions

- **CLI mode only.** The skills' hard rule forbids running `heygen ...` in MCP / OpenClaw-plugin mode, and there is no MCP feedback tool — so the instruction is scoped to CLI mode and explicitly says to skip otherwise.
- **Once per task, at delivery.** Mirrors HyperFrames' "report after verified output" convention and avoids emitting events mid-flow.
- **NanoClaw gets a shorter note** — it's CLI-only with no mode detection, so the MCP/plugin caveat is unnecessary there.

## Testing

Doc-only. Verified `heygen feedback` and its `--rating` / `--comment` flags exist and match the documented usage on stable v0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
